### PR TITLE
Improve pygfx renderer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install poetry
         run: pip install "poetry>=1.1.12,<1.2"
       - name: Install dependencies
-        run: poetry install
+        run: poetry install --extras pygfx
       - name: Test
         run: poetry run pytest --cov=collagraph --cov-report=term-missing
 

--- a/collagraph/__init__.py
+++ b/collagraph/__init__.py
@@ -583,7 +583,7 @@ def equivalent_code(a, b):
     ]:
         attr_a = getattr(a, attr, None)
         attr_b = getattr(b, attr, None)
-        if attr in ["co_freevars", "co_varnames"]:
+        if attr in {"co_freevars", "co_varnames"}:
             # co_varnames and co_freevars can contain names, which might
             # be different but should be similar at least in length
             if len(attr_a) != len(attr_b):

--- a/collagraph/__init__.py
+++ b/collagraph/__init__.py
@@ -382,7 +382,11 @@ class Collagraph:
 
     def update_dom(self, dom: Any, prev_props: Dict, next_props: Dict):
         def is_event(key):
-            return key.startswith("on")
+            return key.startswith("on_")
+
+        def key_to_event(key):
+            # Events start with `on_`
+            return key.lower()[3:]
 
         def is_property(key):
             return not is_event(key)
@@ -403,7 +407,7 @@ class Collagraph:
             ):
                 continue
 
-            event_type = name.lower()[2:]
+            event_type = key_to_event(name)
             self.renderer.remove_event_listener(dom, event_type, val)
 
         # Remove old properties
@@ -434,7 +438,7 @@ class Collagraph:
             if is_equivalent_event_handler(prev_props.get(name), next_props, name):
                 continue
 
-            event_type = name.lower()[2:]
+            event_type = key_to_event(name)
             self.renderer.add_event_listener(dom, event_type, next_props[name])
 
 

--- a/collagraph/__init__.py
+++ b/collagraph/__init__.py
@@ -1,4 +1,3 @@
-from functools import partial
 from importlib.metadata import version
 from itertools import zip_longest
 import logging
@@ -8,6 +7,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from observ import reactive, scheduler, watch
 
+from .compare import equivalent_functions
 from .renderers import DictRenderer, Renderer
 from .types import EffectTag, EventLoopType, Fiber, OpType, VNode
 
@@ -442,18 +442,27 @@ class Collagraph:
             self.renderer.add_event_listener(dom, event_type, next_props[name])
 
 
-def first(items: Iterable, match: Callable, *args):
-    idx = indexOf(items, match, *args)
-    return items[idx] if idx is not None else None
-
-
 def indexOf(items: Iterable, match: Callable, *args):
+    """Returns the index of the first item for which the `match` function returns
+    True."""
     for idx, item in enumerate(items):
         if match(item, *args):
             return idx
 
 
+def first(items: Iterable, match: Callable, *args):
+    """Returns the first item for which the `match` function returns True."""
+    idx = indexOf(items, match, *args)
+    return items[idx] if idx is not None else None
+
+
 def compare(a: Iterable, b: Iterable, match: Callable):
+    """Returns a list of `matches` between a and b and `removals` which contain
+    items that are in b but not in a.
+
+    The list of matches has the same length as a and contains 'None' values at
+    positions for which no match was found in b.
+    """
     b = b.copy()
     matches = []
     for item in a:
@@ -469,6 +478,7 @@ def compare(a: Iterable, b: Iterable, match: Callable):
 
 
 def apply_op(op: Dict, it: Iterable):
+    """Apply a single operation 'op' on a list 'it'."""
     if op["op"] is OpType.MOVE:
         idx = it.index(op["value"])
         val = it.pop(idx)
@@ -537,85 +547,3 @@ def create_ops(current, future):
             apply_op(ops[-1], wip)
 
     return ops
-
-
-def equivalent_functions(a: Callable, b: Callable):
-    """Returns whether function a is equivalent to function b.
-
-    ``functools.partial`` functions are also supported (but only when both
-    argument a and b are partial).
-    """
-    if not hasattr(a, "__code__") or not hasattr(b, "__code__"):
-        if isinstance(a, partial) and isinstance(b, partial):
-            return (
-                a.args == b.args
-                and a.keywords == b.keywords
-                and equivalent_functions(a.func, b.func)
-            )
-
-        return a == b
-
-    return equivalent_code(a.__code__, b.__code__) and equivalent_closure_values(a, b)
-
-
-def equivalent_code(a, b):
-    """Returns True if a and b are equivalent code.
-
-    In order to determine this, a number of properties are compared that
-    should be equal between similar functions.
-    It checks all co_* props of __code__ (as seen in Python 3.9), except for:
-      * co_firstlineno
-      * co_lnotab
-      * co_name
-    because those vars can differ without having any impact on the equivalency
-    of the functions themselves.
-    """
-    for attr in {
-        "co_varnames",
-        "co_argcount",
-        "co_cellvars",
-        "co_code",
-        "co_consts",
-        "co_filename",
-        "co_flags",
-        "co_freevars",
-        "co_kwonlyargcount",
-        "co_names",
-        "co_nlocals",
-        "co_posonlyargcount",
-        "co_stacksize",
-    }:
-        attr_a = getattr(a, attr, None)
-        attr_b = getattr(b, attr, None)
-        if attr in {"co_freevars", "co_varnames"}:
-            # co_varnames and co_freevars can contain names, which might
-            # be different but should be similar at least in length
-            if len(attr_a) != len(attr_b):
-                return False
-        elif attr_a != attr_b:
-            return False
-
-    return True
-
-
-def equivalent_closure_values(a, b):
-    """Compare the cell contents of the __closure__ attribute for the given
-    functions. This method assumes that the code for a and be is already
-    equivalent."""
-    if (closure_a := getattr(a, "__closure__", None)) and (
-        closure_b := getattr(b, "__closure__", None)
-    ):
-        values_a = [cell.cell_contents for cell in closure_a]
-        values_b = [cell.cell_contents for cell in closure_b]
-        if len(values_a) != len(values_b):
-            return False
-
-        for a, b in zip(values_a, values_b):
-            if callable(a) and callable(b):
-                if not equivalent_functions(a, b):
-                    return False
-            else:
-                if a != b:
-                    return False
-
-    return True

--- a/collagraph/__init__.py
+++ b/collagraph/__init__.py
@@ -566,7 +566,7 @@ def equivalent_code(a, b):
     because those vars can differ without having any impact on the equivalency
     of the functions themselves.
     """
-    for attr in [
+    for attr in {
         "co_varnames",
         "co_argcount",
         "co_cellvars",
@@ -580,7 +580,7 @@ def equivalent_code(a, b):
         "co_nlocals",
         "co_posonlyargcount",
         "co_stacksize",
-    ]:
+    }:
         attr_a = getattr(a, attr, None)
         attr_b = getattr(b, attr, None)
         if attr in {"co_freevars", "co_varnames"}:

--- a/collagraph/compare.py
+++ b/collagraph/compare.py
@@ -1,0 +1,84 @@
+from functools import partial
+from typing import Callable
+
+
+def equivalent_functions(a: Callable, b: Callable):
+    """Returns whether function a is equivalent to function b.
+
+    ``functools.partial`` functions are also supported (but only when both
+    argument a and b are partial).
+    """
+    if not hasattr(a, "__code__") or not hasattr(b, "__code__"):
+        if isinstance(a, partial) and isinstance(b, partial):
+            return (
+                a.args == b.args
+                and a.keywords == b.keywords
+                and equivalent_functions(a.func, b.func)
+            )
+
+        return a == b
+
+    return equivalent_code(a.__code__, b.__code__) and equivalent_closure_values(a, b)
+
+
+def equivalent_code(a, b):
+    """Returns True if a and b are equivalent code.
+
+    In order to determine this, a number of properties are compared that
+    should be equal between similar functions.
+    It checks all co_* props of __code__ (as seen in Python 3.9), except for:
+      * co_firstlineno
+      * co_lnotab
+      * co_name
+    because those vars can differ without having any impact on the equivalency
+    of the functions themselves.
+    """
+    for attr in {
+        "co_varnames",
+        "co_argcount",
+        "co_cellvars",
+        "co_code",
+        "co_consts",
+        "co_filename",
+        "co_flags",
+        "co_freevars",
+        "co_kwonlyargcount",
+        "co_names",
+        "co_nlocals",
+        "co_posonlyargcount",
+        "co_stacksize",
+    }:
+        attr_a = getattr(a, attr, None)
+        attr_b = getattr(b, attr, None)
+        if attr in {"co_freevars", "co_varnames"}:
+            # co_varnames and co_freevars can contain names, which might
+            # be different but should be similar at least in length
+            if len(attr_a) != len(attr_b):
+                return False
+        elif attr_a != attr_b:
+            return False
+
+    return True
+
+
+def equivalent_closure_values(a, b):
+    """Compare the cell contents of the __closure__ attribute for the given
+    functions. This method assumes that the code for a and be is already
+    equivalent."""
+    if (closure_a := getattr(a, "__closure__", None)) and (
+        closure_b := getattr(b, "__closure__", None)
+    ):
+        values_a = [cell.cell_contents for cell in closure_a]
+        values_b = [cell.cell_contents for cell in closure_b]
+        if len(values_a) != len(values_b):
+            return False
+
+        for a, b in zip(values_a, values_b):
+            if callable(a) and callable(b):
+                if not equivalent_functions(a, b):
+                    return False
+            else:
+                if a != b:
+                    return False
+
+    return True

--- a/collagraph/renderers/__init__.py
+++ b/collagraph/renderers/__init__.py
@@ -52,4 +52,4 @@ try:
 except ImportError:  # pragma: no cover
     pass
 else:
-    from .pygfx_renderer import PygfxRenderer  # pragma: no cover
+    from .pygfx_renderer import PygfxRenderer

--- a/collagraph/renderers/pygfx_renderer.py
+++ b/collagraph/renderers/pygfx_renderer.py
@@ -26,12 +26,13 @@ class PygfxRenderer(Renderer):
         parent.remove(el)
 
     def set_attribute(self, obj, attr, value):
-        if attr == "position" or attr == "scale":
-            value = gfx.linalg.Vector3(*value)
-        elif attr == "rotation":
-            value = gfx.linalg.Quaternion(*value)
-        elif attr == "matrix":
-            value = gfx.linalg.Matrix4(*value)
+        if isinstance(obj, gfx.WorldObject):
+            if attr == "position" or attr == "scale":
+                value = gfx.linalg.Vector3(*value)
+            elif attr == "rotation":
+                value = gfx.linalg.Quaternion(*value)
+            elif attr == "matrix":
+                value = gfx.linalg.Matrix4(*value)
 
         setattr(obj, attr, value)
 

--- a/collagraph/renderers/pygfx_renderer.py
+++ b/collagraph/renderers/pygfx_renderer.py
@@ -27,7 +27,7 @@ class PygfxRenderer(Renderer):
 
     def set_attribute(self, obj, attr, value):
         if isinstance(obj, gfx.WorldObject):
-            if attr == "position" or attr == "scale":
+            if attr in {"position", "scale"}:
                 value = gfx.linalg.Vector3(*value)
             elif attr == "rotation":
                 value = gfx.linalg.Quaternion(*value)

--- a/collagraph/renderers/pygfx_renderer.py
+++ b/collagraph/renderers/pygfx_renderer.py
@@ -4,6 +4,16 @@ from . import Renderer
 
 
 class PygfxRenderer(Renderer):
+    """Renderer for Pygfx objects"""
+
+    def create_element(self, type: str) -> gfx.WorldObject:
+        """Create pygfx element for the given type"""
+        obj_type = getattr(gfx, type, None)
+        if not obj_type:
+            raise ValueError(f"Can't create element of type: {type}")
+
+        return obj_type()
+
     def insert(
         self,
         el: gfx.WorldObject,
@@ -14,14 +24,6 @@ class PygfxRenderer(Renderer):
 
     def remove(self, el: gfx.WorldObject, parent: gfx.WorldObject):
         parent.remove(el)
-
-    def create_element(self, type: str) -> gfx.WorldObject:
-        """Create pygfx element for the given type"""
-        obj_type = getattr(gfx, type, None)
-        if not obj_type:
-            raise ValueError(f"Can't create element of type: {type}")
-
-        return obj_type()
 
     def set_attribute(self, obj, attr, value):
         if attr == "position" or attr == "scale":

--- a/collagraph/renderers/pygfx_renderer.py
+++ b/collagraph/renderers/pygfx_renderer.py
@@ -1,30 +1,6 @@
-from collections import defaultdict
-
 import pygfx as gfx
 
 from . import Renderer
-
-
-class MeshEvents(gfx.Mesh):
-    """Custom subclass of gfx.Mesh to enable handling of events."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._event_handlers = defaultdict(set)
-
-    def add_event_handler(self, type, callback):
-        """Register an event handler."""
-        self._event_handlers[type].add(callback)
-
-    def handle_event(self, event):
-        """Handle an incoming event."""
-        event_type = event.get("event_type")
-        for callback in self._event_handlers[event_type]:
-            callback(event)
-
-    def remove_event_handler(self, type, callback):
-        """Unregister an event handler."""
-        self._event_handlers[type].remove(callback)
 
 
 class PygfxRenderer(Renderer):
@@ -41,40 +17,27 @@ class PygfxRenderer(Renderer):
 
     def create_element(self, type: str) -> gfx.WorldObject:
         """Create pygfx element for the given type"""
-        if type == "Point":
-            # NOTE: geometry and material should preferably be passed through
-            # state instead of generated here, because they are resources that
-            # can be shared
-            obj = MeshEvents(gfx.sphere_geometry(), gfx.MeshPhongMaterial())
-        if type == "Group":
-            obj = gfx.Group()
-        if type == "Mesh":
-            obj = MeshEvents()
-        return obj
+        obj_type = getattr(gfx, type, None)
+        if not obj_type:
+            raise ValueError(f"Can't create element of type: {type}")
+
+        return obj_type()
 
     def set_attribute(self, obj, attr, value):
-        if attr == "color":
-            obj.material.color = value
-            return
-
-        if hasattr(value, "__len__") and len(value) == 3:
+        if attr == "position" or attr == "scale":
             value = gfx.linalg.Vector3(*value)
+        elif attr == "rotation":
+            value = gfx.linalg.Quaternion(*value)
+        elif attr == "matrix":
+            value = gfx.linalg.Matrix4(*value)
+
         setattr(obj, attr, value)
 
     def remove_attribute(self, obj, attr, value):
-        # TODO: define some kind of defaults for pygfx objects?
-        if attr == "color":
-            obj.material.color = (1, 1, 1, 1)
-            return
-
-        if hasattr(value, "__len__") and len(value) == 3:
-            value = gfx.linalg.Vector3()
-        else:
-            value = None
-        setattr(obj, attr, value)
+        raise NotImplementedError
 
     def add_event_listener(self, el, event_type, value):
-        el.add_event_handler(event_type, value)
+        el.add_event_handler(value, event_type)
 
     def remove_event_listener(self, el, event_type, value):
-        el.remove_event_handler(event_type, value)
+        el.remove_event_handler(value, event_type)

--- a/examples/pygfx-example.py
+++ b/examples/pygfx-example.py
@@ -126,7 +126,6 @@ if __name__ == "__main__":
             {
                 "name": "Hip",
                 "position": [2, 2, 2],
-                "color": [1, 0.4, 0],
                 "geometry": sphere_geom,
                 "material": materials["other"],
             },

--- a/examples/pygfx-example.py
+++ b/examples/pygfx-example.py
@@ -33,27 +33,12 @@ from collagraph import Collagraph, create_element as h, EventLoopType
 from collagraph.renderers import PygfxRenderer
 
 
-class SelectableObjectsCanvas(WgpuCanvas):
-    def _object_under_pointer(self, event):
-        info = renderer.get_pick_info((event["x"], event["y"]))
-        return info["world_object"]
-
-    def handle_click(self, event):
-        if wobject := self._object_under_pointer(event):
-            if handle_event := getattr(wobject, "handle_event", None):
-                handle_event({"event_type": "click"})
-
-    def handle_move(self, event):
-        if wobject := self._object_under_pointer(event):
-            if handle_event := getattr(wobject, "handle_event", None):
-                handle_event({"event_type": "hover"})
-
-
 sphere_geom = gfx.sphere_geometry(radius=0.5)
 materials = {
     "default": gfx.MeshPhongMaterial(color=[1, 1, 1]),
     "selected": gfx.MeshPhongMaterial(color=[1, 0, 0]),
     "hovered": gfx.MeshPhongMaterial(color=[1, 0.6, 0]),
+    "other": gfx.MeshPhongMaterial(color=[1, 0, 0.5]),
 }
 
 
@@ -92,7 +77,7 @@ def PointCloud(props):
                 ],
                 "key": index,
                 "onClick": lambda event: set_selected(index),
-                "onHover": lambda event: set_hovered(index),
+                "onPointer_move": lambda event: set_hovered(index),
             },
         )
 
@@ -108,49 +93,15 @@ def PointCloud(props):
     )
 
 
-def Landmark(props):
-    props.setdefault("selected", False)
-
-    def toggle():
-        props["selected"] = not props["selected"]
-
-    return h(
-        "Group",
-        props,
-        h(
-            "Point",
-            {
-                "scale": [2 if props["selected"] else 1] * 3,
-                "color": [1, 0.5, 0, 0.1],
-            },
-        ),
-        h(
-            "Point",
-            {
-                "scale": [0.5, 0.5, 0.5],
-                "color": [1, 1, 1, 1],
-                "onClick": lambda event: toggle(),
-            },
-        ),
-    )
-
-
 if __name__ == "__main__":
-    canvas = SelectableObjectsCanvas(size=(600, 400))
-    canvas.add_event_handler(canvas.handle_move, "pointer_move")
-    canvas.add_event_handler(canvas.handle_click, "pointer_down")
-    # Newer releases of pygfx don't need the following patch for Qt autogui
-    try:
-        canvas.setMouseTracking(True)
-        canvas._subwidget.setMouseTracking(True)
-    except ValueError:
-        pass
+    canvas = WgpuCanvas(size=(600, 400))
     renderer = gfx.renderers.WgpuRenderer(canvas)
+
     camera = gfx.PerspectiveCamera(60, 16 / 9)
     camera.position.z = 15
 
     controls = gfx.OrbitControls(camera.position.clone())
-    controls.add_default_event_handlers(canvas, camera)
+    controls.add_default_event_handlers(renderer, canvas, camera)
 
     gui = Collagraph(renderer=PygfxRenderer(), event_loop_type=EventLoopType.QT)
 
@@ -168,34 +119,16 @@ if __name__ == "__main__":
             # When increasing this number, it will take longer
             # and longer for pygfx to create the render pipeline
             # (compiling shaders and such), so be careful...
-            # {"count": 20},
+            {"count": 50},
         ),
         h(
-            Landmark,
-            {
-                "name": "funk",
-            },
-        ),
-        h(
-            Landmark,
-            {
-                "position": [4, 4, -4],
-            },
-        ),
-        h(
-            "Point",
+            "Mesh",
             {
                 "name": "Hip",
                 "position": [2, 2, 2],
                 "color": [1, 0.4, 0],
-            },
-        ),
-        h(
-            "Point",
-            {
-                "name": "Hap",
-                "position": [-2, 0, -6],
-                "color": [0.8, 1, 0],
+                "geometry": sphere_geom,
+                "material": materials["other"],
             },
         ),
     )

--- a/examples/pygfx-example.py
+++ b/examples/pygfx-example.py
@@ -76,8 +76,8 @@ def PointCloud(props):
                     random.randint(-10, 10),
                 ],
                 "key": index,
-                "onClick": lambda event: set_selected(index),
-                "onPointer_move": lambda event: set_hovered(index),
+                "on_click": lambda event: set_selected(index),
+                "on_pointer_move": lambda event: set_hovered(index),
             },
         )
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -478,11 +478,18 @@ description = "A threejs-like render engine based on wgpu"
 category = "main"
 optional = true
 python-versions = ">=3.7.0"
+develop = false
 
 [package.dependencies]
 Jinja2 = "*"
 numpy = "*"
-wgpu = ">=0.7.4,<0.8.0"
+wgpu = ">=0.7.5,<0.8.0"
+
+[package.source]
+type = "git"
+url = "https://github.com/pygfx/pygfx.git"
+reference = "main"
+resolved_reference = "57e6c45c9e9516e90d768dc683b2033ab6bcb409"
 
 [[package]]
 name = "pygments"
@@ -757,7 +764,7 @@ python-versions = "*"
 
 [[package]]
 name = "wgpu"
-version = "0.7.4"
+version = "0.7.5"
 description = "Next generation GPU API for Python"
 category = "main"
 optional = true
@@ -790,7 +797,7 @@ pyside = ["PySide6"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8"
-content-hash = "f9307c532ff9a1753d42e955702ca548e09502b939f284d178a15d20b8462950"
+content-hash = "f349eda8953f463c31be9462f137fb10bda205b71190a1ec24d680f69d9cf907"
 
 [metadata.files]
 atomicwrites = [
@@ -1146,10 +1153,7 @@ pyflakes = [
     {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
-pygfx = [
-    {file = "pygfx-0.1.7-py3-none-any.whl", hash = "sha256:33103b77c02f15d59cec53c1b371cceb1a457f0fce50cda864b08d24f8e23ed8"},
-    {file = "pygfx-0.1.7.tar.gz", hash = "sha256:7c444daf2ec3252a9663ae77017fb1627c8a4d36d50735da1c7426e82a6d1673"},
-]
+pygfx = []
 pygments = [
     {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
     {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
@@ -1276,13 +1280,13 @@ webencodings = [
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
 ]
 wgpu = [
-    {file = "wgpu-0.7.4-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:be10689be462ae34bc518a2a129517c1f6a39371401d946f7e3f50c7cdf5e757"},
-    {file = "wgpu-0.7.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2253b3b556d76078d35c94737b99d50deedc73342fa095b9657e8b9f5a45f75b"},
-    {file = "wgpu-0.7.4-py3-none-manylinux_2_24_i686.whl", hash = "sha256:39b7f40ae69a82deb1a6427fdc74d3fc3dbf9fc39c2984f71c97f234ff65a19c"},
-    {file = "wgpu-0.7.4-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:fee87ae4e0d607cec6582406a7a485224af10d1a4810d22a6af017a9092e2413"},
-    {file = "wgpu-0.7.4-py3-none-win32.whl", hash = "sha256:ef2695ff959495f0bbae160a8e26692ebb4e3060b2e88c49428f9fa3bf4dc82d"},
-    {file = "wgpu-0.7.4-py3-none-win_amd64.whl", hash = "sha256:3fce6b6ab598f1c360c8fd06b7f707bbc90c85950aadbc7de0593a0b47ce05e0"},
-    {file = "wgpu-0.7.4.tar.gz", hash = "sha256:b17bc431b4027f0e0e87605a735ea5d9d2659fb13892afb024c7f698facb72ce"},
+    {file = "wgpu-0.7.5-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:2aec6ac9612609e059d1ad485f5b28a8b8be1d730db27d8ccb161932712d3615"},
+    {file = "wgpu-0.7.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2eeeb4cbf435badd159e9a708baea70c2ab8858252e79b57f37cda243f7ff8ad"},
+    {file = "wgpu-0.7.5-py3-none-manylinux_2_24_i686.whl", hash = "sha256:d8f184d8e8f02753edcfd78ec08118b02e8e31d616eac0a8bca70bb9beb4acb4"},
+    {file = "wgpu-0.7.5-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:bcb8a05e1063bbde6c333c2c0f2d773c54802524fc3bfaac39ad0502c951ce06"},
+    {file = "wgpu-0.7.5-py3-none-win32.whl", hash = "sha256:962913206aa743c54034eb4b0a86f5c15f4a1a4a95749da4696affb5ae76d0b7"},
+    {file = "wgpu-0.7.5-py3-none-win_amd64.whl", hash = "sha256:b042bcd0457cd886320746212daa7cdb76bba6b998b12b9d61589931faa1c0ae"},
+    {file = "wgpu-0.7.5.tar.gz", hash = "sha256:5007a51a41200becfebaa334bfebe3469f671c6507173d713413951674c7d0a2"},
 ]
 zipp = [
     {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ pyside = ["PySide6"]
 [tool.poetry.dependencies]
 python = ">=3.8"
 observ = "~0.9.1"
-pygfx = { version = "~0.1.7", optional = true }
+# pygfx = { version = "~0.1.7", optional = true }
+pygfx = { git = "https://github.com/pygfx/pygfx.git", branch = "main", optional = true }
 PySide6 = { version = "*", python = "<3.11", optional = true }
 
 [tool.poetry.dev-dependencies]

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,3 @@ import-order-style = google
 per-file-ignores =
     collagraph/renderers/__init__.py: E402, F401
 exclude = .venv
-
-[coverage:run]
-omit =
-    collagraph/renderers/pygfx_renderer.py

--- a/tests/test_collagraph.py
+++ b/tests/test_collagraph.py
@@ -60,7 +60,7 @@ def test_reactive_element_with_events(process_events):
             props["count"] += 1
 
         return h(
-            "counter", props, h("count", {"count": props["count"], "onBump": bump})
+            "counter", props, h("count", {"count": props["count"], "on_bump": bump})
         )
 
     renderer = DictRenderer()
@@ -217,7 +217,7 @@ def test_update_element_with_event(process_events):
             props["count"] += 1
 
         props.setdefault("count", 0)
-        props.setdefault("onBump", bump)
+        props.setdefault("on_bump", bump)
 
         return h("counter", props)
 
@@ -268,12 +268,12 @@ def test_add_remove_event_handlers(process_events):
         def reset():
             props["count"] = 0
             # Remove reset handler
-            del props["onReset"]
+            del props["on_reset"]
 
         props.setdefault("count", 0)
         if props["count"] > 0:
             # Add reset handler
-            props["onReset"] = reset
+            props["on_reset"] = reset
 
         return h("counter", props)
 
@@ -298,7 +298,7 @@ def test_add_remove_event_handlers(process_events):
 
     process_events()
 
-    assert "onReset" not in state
+    assert "on_reset" not in state
     assert len(container["children"][0]["handlers"]["reset"]) == 0
 
 
@@ -306,13 +306,13 @@ def test_change_event_handler(process_events):
     def Tick(props):
         def tick():
             props["value"] = "Tick"
-            props["onToggle"] = tock
+            props["on_toggle"] = tock
 
         def tock():
             props["value"] = "Tock"
-            props["onToggle"] = tick
+            props["on_toggle"] = tick
 
-        props.setdefault("onToggle", tock)
+        props.setdefault("on_toggle", tock)
         props.setdefault("value", "...")
         return h("counter", props)
 

--- a/tests/test_compare_functions.py
+++ b/tests/test_compare_functions.py
@@ -108,3 +108,22 @@ def test_closures():
     assert b() == "b"
 
     assert not equivalent_functions(a, b)
+
+
+def test_similar_lambda_function_which_captures_other_function():
+    def double(a):
+        return a * 2
+
+    def other_double(b):
+        return b * 2
+
+    def add(c):
+        return c + 2
+
+    x = lambda a: double(a)  # noqa: E731
+    y = lambda b: other_double(b)  # noqa: E731
+    z = lambda c: add(c)  # noqa: E731
+
+    assert equivalent_functions(x, y)
+    assert not equivalent_functions(x, z)
+    assert not equivalent_functions(y, z)

--- a/tests/test_pygfx_renderer.py
+++ b/tests/test_pygfx_renderer.py
@@ -1,0 +1,102 @@
+from collections import namedtuple
+
+import pytest
+
+try:
+    import pygfx as gfx
+except ImportError:
+    pytest.skip(reason="pygfx not installed", allow_module_level=True)
+
+from collagraph.renderers import PygfxRenderer
+
+
+def test_pygfx_create_element():
+    renderer = PygfxRenderer()
+
+    obj = renderer.create_element("Scene")
+    assert isinstance(obj, gfx.Scene)
+
+    obj = renderer.create_element("Mesh")
+    assert isinstance(obj, gfx.Mesh)
+
+    obj = renderer.create_element("MeshBasicMaterial")
+    assert isinstance(obj, gfx.MeshBasicMaterial)
+
+    with pytest.raises(ValueError):
+        renderer.create_element("Foo")
+
+
+def test_pygfx_insert_remove():
+    renderer = PygfxRenderer()
+
+    parent = gfx.Scene()
+
+    child1 = gfx.WorldObject()
+    child2 = gfx.WorldObject()
+
+    renderer.insert(child1, parent)
+    assert parent.children == (child1,)
+
+    renderer.insert(child2, parent)
+    assert parent.children == (child1, child2)
+
+    renderer.insert(child2, parent, anchor=child1)
+    assert parent.children == (child2, child1)
+
+    renderer.remove(child2, parent)
+    assert parent.children == (child1,)
+
+    renderer.remove(child1, parent)
+    assert parent.children == ()
+
+
+def test_pygfx_attributes():
+    renderer = PygfxRenderer()
+
+    mesh = gfx.Mesh()
+
+    renderer.set_attribute(mesh, "name", "foo")
+    assert mesh.name == "foo"
+
+    renderer.set_attribute(mesh, "position", [3, 2, 5])
+    assert mesh.position == gfx.linalg.Vector3(3, 2, 5)
+
+    renderer.set_attribute(mesh, "rotation", [1, 2, 3, 4])
+    assert mesh.rotation == gfx.linalg.Quaternion(1, 2, 3, 4)
+
+    renderer.set_attribute(mesh, "matrix", [1] * 16)
+    assert mesh.matrix == gfx.linalg.Matrix4(*[1] * 16)
+
+    material = gfx.Material()
+
+    renderer.set_attribute(material, "color", [1, 0.5, 0, 0.8])
+    assert material.color == [1, 0.5, 0, 0.8]
+
+    # The pygfx renderer does not support removing attributes
+    with pytest.raises(NotImplementedError):
+        renderer.remove_attribute(material, "color", [1, 0.5, 0, 0.8])
+
+
+def test_event_handlers():
+    renderer = PygfxRenderer()
+
+    count = 0
+
+    def counter(event):
+        nonlocal count
+        count += 1
+
+    obj = gfx.Scene()
+    renderer.add_event_listener(obj, "click", counter)
+
+    Event = namedtuple("Event", ["type", "cancelled"], defaults=[False])
+    event = Event("click")
+    obj.handle_event(event)
+
+    assert count == 1
+
+    renderer.remove_event_listener(obj, "click", counter)
+
+    obj.handle_event(event)
+
+    assert count == 1


### PR DESCRIPTION
The pygfx renderer can now just create objects that are defined in the pygfx top package. Some attributes (`position`, `scale`, `rotation`, `matrix`) have a specific type, so the value is transformed into the expected type (Vector3, Quaternion, Matrix4).

Bonus: during the rewrite of the example, I came across a problem with the event handlers being removed/added on each mouse-hover. I found that the search for equivalency was not 'deep' enough yet, because the values within the `__closure__` can also be functions, which should also be checked for equivalency; not equality. Also added a test for this scenario.