### PR TITLE
Add element property to component class

### DIFF
--- a/collagraph/__init__.py
+++ b/collagraph/__init__.py
@@ -396,6 +396,7 @@ class Collagraph:
 
             if fiber.mounted:
                 if fiber.component:
+                    fiber.component.element = fiber.child.dom
                     fiber.component.mounted()
                 fiber.mounted = False
                 fiber.updated = False

--- a/collagraph/component.py
+++ b/collagraph/component.py
@@ -54,7 +54,3 @@ class Component(metaclass=ABCMeta):
     @abstractmethod
     def render():  # pragma: no cover
         pass
-
-    def __del__(self):
-        # Make sure to clean-up _element.
-        self._element = None

--- a/collagraph/component.py
+++ b/collagraph/component.py
@@ -1,5 +1,4 @@
 from abc import ABCMeta, abstractmethod
-from weakref import ref
 
 from observ import reactive, readonly
 
@@ -15,17 +14,12 @@ class Component(metaclass=ABCMeta):
     @property
     def element(self):
         """The root DOM element of this component."""
-        return self._element and self._element()
+        return self._element
 
     @element.setter
     def element(self, value):
         """Setter that is used by the internals of Collagraph. Please don't use this."""
-        try:
-            self._element = ref(value)
-        except TypeError:
-            # It is not possible to create weak refs to dicts and lists
-            # so instead wrap the element in a lambda.
-            self._element = lambda: value
+        self._element = value
 
     def mounted(self):
         """Called after the component has been mounted.
@@ -62,7 +56,5 @@ class Component(metaclass=ABCMeta):
         pass
 
     def __del__(self):
-        # Make sure to clean-up _element. Normally this shouldn't be needed as it is
-        # a weak ref, but if a type of element was set for which no weak ref can be
-        # made, we still need to do the clean-up.
+        # Make sure to clean-up _element.
         self._element = None

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -219,3 +219,26 @@ def test_component_props_deep_update():
 
     assert container["children"][0]["attrs"]["prop"] == [0, 1, 2]
     assert Counter.updates == 1
+
+
+def test_component_element():
+    component = None
+
+    class SpecialComponent(Component):
+        def mounted(self):
+            nonlocal component
+            component = self
+
+        def render(self):
+            return h("special")
+
+    gui = Collagraph(event_loop_type=EventLoopType.SYNC)
+    container = {"type": "root"}
+    state = reactive({"count": 0})
+    element = h(SpecialComponent, state)
+
+    gui.render(element, container)
+
+    assert component is not None
+    assert isinstance(component, SpecialComponent)
+    assert component.element is container["children"][0]


### PR DESCRIPTION
This adds the property `element` as a weak ref to the root DOM element of the rendered component.

Needed for combining the PySide6 renderer with the Pygfx renderer.