### PR TITLE
Improve debugging experience

### DIFF
--- a/examples/debug.py
+++ b/examples/debug.py
@@ -1,0 +1,11 @@
+import collagraph as cg
+
+from debug_example import DebugExample  # noqa: I100
+
+
+if __name__ == "__main__":
+    container = {"type": "root"}
+    gui = cg.Collagraph(event_loop_type=cg.EventLoopType.SYNC)
+    gui.render(cg.h(DebugExample), container)
+
+    print(container)  # noqa: T001

--- a/examples/debug_example.cgx
+++ b/examples/debug_example.cgx
@@ -1,0 +1,13 @@
+<template>
+  <example :value="get_value()" />
+</template>
+
+<script lang="python">
+import collagraph as cg
+
+
+class DebugExample(cg.Component):
+    def get_value(self):
+        breakpoint()
+        return "foo"
+</script>


### PR DESCRIPTION
Closes #35 .

The ast of the data in the script tag is now adjusted to match with the location in the cgx file. By also passing the name of the file to the compile command, the debugger can figure out where the code is located that is executed.
And instead of inserting nodes at the start of the tree, they are now appended so they don't mess with the line numbers.

Please see the new example [example/debug.py]() which loads [example/debug_example.cgx]() which has a `breakpoint()` set.