### PR TITLE
Component events

### DIFF
--- a/collagraph/collagraph.py
+++ b/collagraph/collagraph.py
@@ -487,14 +487,14 @@ class Collagraph:
         attrs_to_remove = {}
         attrs_to_update = {}
         events_to_add = {}
-        equavalent_event_handlers = set()
+        equivalent_event_handlers = set()
 
         for key, val in prev_props.items():
             if is_event(key):
                 if key in next_props and is_equivalent_event_handler(
                     val, next_props, key
                 ):
-                    equavalent_event_handlers.add(key)
+                    equivalent_event_handlers.add(key)
                     continue
 
                 event_type = key_to_event(key)
@@ -506,7 +506,7 @@ class Collagraph:
 
         for key, val in next_props.items():
             if is_event(key):
-                if key in equavalent_event_handlers:
+                if key in equivalent_event_handlers:
                     continue
 
                 event_type = key_to_event(key)

--- a/collagraph/collagraph.py
+++ b/collagraph/collagraph.py
@@ -538,10 +538,6 @@ class Collagraph:
                     if component:
                         # Mark the fiber as updated
                         parent.updated = True
-                        for event_type, val in events_to_remove.items():
-                            component.remove_event_handler(event_type, val)
-                        for event_type, val in events_to_add.items():
-                            component.add_event_handler(event_type, val)
                         break
                     parent = parent.parent
 

--- a/collagraph/components/__init__.py
+++ b/collagraph/components/__init__.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from collections import defaultdict
 
 from observ import reactive, readonly
 
@@ -12,6 +13,8 @@ class Component:
         self.props = readonly({} if props is None else props)
         self.state = reactive({})
         self._element = None
+        self._parent = None
+        self._event_handlers = defaultdict(set)
 
     @property
     def element(self):
@@ -56,3 +59,17 @@ class Component:
     @abstractmethod
     def render():  # pragma: no cover
         pass
+
+    def emit(self, event, *args, **kwargs):
+        if self._parent:
+            self._parent.handle_event(event, *args, **kwargs)
+
+    def add_event_handler(self, event, handler):
+        self._event_handlers[event].add(handler)
+
+    def remove_event_handler(self, event, handler):
+        self._event_handlers[event].remove(handler)
+
+    def handle_event(self, event, *args, **kwargs):
+        for handler in self._event_handlers[event].copy():
+            handler(*args)

--- a/collagraph/components/__init__.py
+++ b/collagraph/components/__init__.py
@@ -60,14 +60,15 @@ class Component:
         pass
 
     def emit(self, event, *args, **kwargs):
-        self.handle_event(event, *args, **kwargs)
+        """Call event handlers for the given event. Any args and kwargs will be passed
+        on to the registered handlers."""
+        for handler in self._event_handlers[event].copy():
+            handler(*args, **kwargs)
 
     def add_event_handler(self, event, handler):
+        """Adds an event handler for the given event."""
         self._event_handlers[event].add(handler)
 
     def remove_event_handler(self, event, handler):
+        """Removes an event handler for the given event."""
         self._event_handlers[event].remove(handler)
-
-    def handle_event(self, event, *args, **kwargs):
-        for handler in self._event_handlers[event].copy():
-            handler(*args)

--- a/collagraph/components/__init__.py
+++ b/collagraph/components/__init__.py
@@ -13,7 +13,6 @@ class Component:
         self.props = readonly({} if props is None else props)
         self.state = reactive({})
         self._element = None
-        self._parent = None
         self._event_handlers = defaultdict(set)
 
     @property
@@ -61,8 +60,7 @@ class Component:
         pass
 
     def emit(self, event, *args, **kwargs):
-        if self._parent:
-            self._parent.handle_event(event, *args, **kwargs)
+        self.handle_event(event, *args, **kwargs)
 
     def add_event_handler(self, event, handler):
         self._event_handlers[event].add(handler)

--- a/tests/pyside/test_pyside_elements.py
+++ b/tests/pyside/test_pyside_elements.py
@@ -273,7 +273,7 @@ def test_lists(qapp, qtbot, qtmodeltester):
         assert model.findItems("ITEM", column=1)
         qtmodeltester.check(model)
 
-    qtbot.waitUntil(check_model_does_not_contain_foo)
+    qtbot.waitUntil(check_model_does_not_contain_foo, timeout=500)
 
 
 @pytest.mark.skip("QMenuBar prevents destruction of QMainWindow")

--- a/tests/pyside/test_pyside_renderer.py
+++ b/tests/pyside/test_pyside_renderer.py
@@ -148,7 +148,7 @@ def test_pyside_event_listeners(qapp, qtbot):
         button = container.findChild(QtWidgets.QPushButton)
         assert button
 
-    qtbot.waitUntil(check_button)
+    qtbot.waitUntil(check_button, timeout=500)
 
     qtbot.mouseClick(button, QtCore.Qt.LeftButton)
     assert clicked == 1
@@ -159,7 +159,7 @@ def test_pyside_event_listeners(qapp, qtbot):
         assert label.text() == "Bar"
         button = container.findChild(QtWidgets.QPushButton)
 
-    qtbot.waitUntil(check_wait)
+    qtbot.waitUntil(check_wait, timeout=500)
 
     qtbot.mouseClick(button, QtCore.Qt.LeftButton)
     # The callback should have been removed at this point

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -86,7 +86,7 @@ def test_component_basic_lifecycle():
         props.setdefault("counters", [])
 
         return h(
-            "counters", props, *[h(SpecialCounter, prop) for prop in props["counters"]]
+            "counters", {}, *[h(SpecialCounter, prop) for prop in props["counters"]]
         )
 
     gui = Collagraph(event_loop_type=EventLoopType.SYNC)

--- a/tests/test_component_events.py
+++ b/tests/test_component_events.py
@@ -1,0 +1,77 @@
+import collagraph as cg
+
+
+def test_components_events():
+    counter = 0
+    parent = None
+    child = None
+
+    class Parent(cg.Component):
+        def __init__(self, props):
+            super().__init__(props)
+            nonlocal parent
+            parent = self
+
+        def bump(self):
+            nonlocal counter
+            counter += 1
+
+        def bump_with_arg(self, step):
+            nonlocal counter
+            counter += step
+
+        def render(self):
+            return cg.h(
+                "parent",
+                {
+                    "on_bump": self.bump,
+                    "on_bump_step": self.bump_with_arg,
+                },
+                cg.h(Child),
+            )
+
+    class Child(cg.Component):
+        def __init__(self, props):
+            super().__init__(props)
+            nonlocal child
+            child = self
+
+        def simple_event(self):
+            self.emit("bump")
+
+        def event_with_arg(self):
+            self.emit("bump_step", 4)
+
+        def render(self):
+            return cg.h(
+                "child",
+                {
+                    "on_simple_event": self.simple_event,
+                    "on_event_with_arg": self.event_with_arg,
+                },
+            )
+
+    gui = cg.Collagraph(event_loop_type=cg.EventLoopType.SYNC)
+    container = {"type": "root"}
+    gui.render(cg.h(Parent), container)
+
+    assert parent._parent is None
+    assert child._parent is parent
+
+    parent_dom = container["children"][0]
+    child_dom = parent_dom["children"][0]
+
+    assert parent_dom["type"] == "parent"
+    assert child_dom["type"] == "child"
+    assert counter == 0
+    assert "simple_event" in child_dom["handlers"]
+
+    for handler in child_dom["handlers"]["simple_event"]:
+        handler()
+
+    assert counter == 1
+
+    for handler in child_dom["handlers"]["event_with_arg"]:
+        handler()
+
+    assert counter == 5


### PR DESCRIPTION
Closes #20 .

Components can now emit events. Other components can add/remove event handlers for these events.

Bonus: removed some unneeded double loops and comparisons from `update_dom` (which is now renamed to `update_dom_or_component`) and moved some function definitions outside of the `update_dom`.