### PR TITLE
Fix pyside complete re-render

### DIFF
--- a/collagraph/cgx/cgx.py
+++ b/collagraph/cgx/cgx.py
@@ -528,6 +528,12 @@ class CGXParser(HTMLParser):
         original_tag = complete_tag[index : index + len(tag)]
         node = Node(original_tag, dict(attrs), self.getpos())
 
+        # Cast attributes that have no value to boolean (True)
+        # so that they function like flags
+        for key, value in node.attrs.items():
+            if value is None:
+                node.attrs[key] = True
+
         # Add item as child to the last on the stack
         self.stack[-1].children.append(node)
         # Make the new node the last on the stack

--- a/collagraph/renderers/pyside/objects/widget.py
+++ b/collagraph/renderers/pyside/objects/widget.py
@@ -100,7 +100,7 @@ def set_attribute(self, attr, value):
                     call_method(method, val)
         return
     elif attr == "grid_index":
-        setattr(self, "grid_index", value)
+        self.grid_index = value
         if parent := self.parent():
             layout = parent.layout()
             layout.addWidget(self, *value)

--- a/collagraph/renderers/pyside_renderer.py
+++ b/collagraph/renderers/pyside_renderer.py
@@ -148,11 +148,7 @@ class PySideRenderer(Renderer):
         # are created. Otherwise we might experience a
         # hard segfault.
         if not hasattr(self, "_app"):
-            setattr(
-                self,
-                "_app",
-                QtCore.QCoreApplication.instance() or QtWidgets.QApplication(),
-            )
+            self._app = QtCore.QCoreApplication.instance() or QtWidgets.QApplication()
 
         # Create dynamic subclasses which implement `insert`, `set_attribute`
         # and `remove` methods.
@@ -231,7 +227,7 @@ class PySideRenderer(Renderer):
         if signal and hasattr(signal, "connect"):
             # Add a slots attribute to hold all the generated slots, keyed on event_type
             if not hasattr(el, "slots"):
-                setattr(el, "slots", defaultdict(set))
+                el.slots = defaultdict(set)
 
             # Create a slot with the given value
             # Note that the slot apparently does not need arguments to specify the type

--- a/collagraph/renderers/pyside_renderer.py
+++ b/collagraph/renderers/pyside_renderer.py
@@ -207,6 +207,9 @@ class PySideRenderer(Renderer):
 
     def remove(self, el: Any, parent: Any):
         """Remove the element `el` from the children of the element `parent`."""
+        if isinstance(parent, QtWidgets.QApplication):
+            el.close()
+            return
         parent.remove(el)
 
     def set_attribute(self, el: Any, attr: str, value: Any):

--- a/tests/cgx/test_cgx_template_directives.py
+++ b/tests/cgx/test_cgx_template_directives.py
@@ -72,8 +72,8 @@ def test_directive_if():
     assert node.type == "widget"
 
     assert len(node.children) == 1
-    node.children[0].type == "label"
-    node.children[0].props["text"] == "Foo"
+    assert node.children[0].type == "label"
+    assert node.children[0].props["text"] == "Foo"
 
     state["show"] = False
     node = component.render()
@@ -91,16 +91,16 @@ def test_directive_if_elaborate():
     assert node.type == "widget"
 
     assert len(node.children) == 2
-    node.children[0].type == "label"
-    node.children[0].props["text"] == "Foo"
-    node.children[1].props["text"] == "Bar"
+    assert node.children[0].type == "label"
+    assert node.children[0].props["text"] == "Foo"
+    assert node.children[1].props["text"] == "Bar"
 
     state["show"] = False
     node = component.render()
 
     assert len(node.children) == 1
 
-    node.children[0].props["text"] == "Bar"
+    assert node.children[0].props["text"] == "Bar"
 
 
 def test_directive_else():
@@ -113,15 +113,15 @@ def test_directive_else():
     assert node.type == "widget"
 
     assert len(node.children) == 1
-    node.children[0].type == "label"
-    node.children[0].props["text"] == "Foo"
+    assert node.children[0].type == "label"
+    assert node.children[0].props["text"] == "Foo"
 
     state["show"] = False
     node = component.render()
 
     assert len(node.children) == 1
-    node.children[0].type == "label"
-    node.children[0].props["text"] == "Bar"
+    assert node.children[0].type == "label"
+    assert node.children[0].props["text"] == "Bar"
 
 
 def test_directive_else_if():
@@ -134,29 +134,29 @@ def test_directive_else_if():
     assert node.type == "widget"
 
     assert len(node.children) == 1
-    node.children[0].type == "label"
-    node.children[0].props["text"] == "Foo"
+    assert node.children[0].type == "label"
+    assert node.children[0].props["text"] == "Foo"
 
     state["foo"] = False
     node = component.render()
 
     assert len(node.children) == 1
-    node.children[0].type == "label"
-    node.children[0].props["text"] == "Bar"
+    assert node.children[0].type == "label"
+    assert node.children[0].props["text"] == "Bar"
 
     state["bar"] = False
     node = component.render()
 
     assert len(node.children) == 1
-    node.children[0].type == "label"
-    node.children[0].props["text"] == "Baz"
+    assert node.children[0].type == "label"
+    assert node.children[0].props["text"] == "Baz"
 
     state["baz"] = False
     node = component.render()
 
     assert len(node.children) == 1
-    node.children[0].type == "label"
-    node.children[0].props["text"] == "Bas"
+    assert node.children[0].type == "label"
+    assert node.children[0].props["text"] == "Bas"
 
 
 def test_directive_for():
@@ -214,4 +214,5 @@ def test_directive_boolean_casting():
     assert len(node.children) == 1
 
     label = node.children[0]
-    label.props["disabled"] is True
+    assert "disabled" in label.props
+    assert label.props["disabled"] is True

--- a/tests/pyside/test_pyside_elements.py
+++ b/tests/pyside/test_pyside_elements.py
@@ -157,7 +157,7 @@ def test_lists(qapp, qtbot, qtmodeltester):
                 props["items"].pop(0)
 
         children = []
-        for row, (item, check_state) in enumerate(props["items"]):
+        for row, (item, _) in enumerate(props["items"]):
             for column, text in enumerate(item):
                 children.append(
                     h("QStandardItem", {"text": text, "model_index": (row, column)})

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -91,7 +91,6 @@ def test_reconcile_by_key():
         container = CustomElement()
         container.type = "root"
         container.children = []
-        # print(f"-- {name} --")
         state = reactive({"items": before})
         element = h(Items, state)
 
@@ -101,7 +100,7 @@ def test_reconcile_by_key():
 
         for idx, val in enumerate(before):
             item = items.children[idx]
-            assert item.content == val
+            assert item.content == val, name
 
         children_refs = [ref(x) for x in items.children]
 
@@ -109,12 +108,12 @@ def test_reconcile_by_key():
 
         for idx, val in enumerate(after):
             item = items.children[idx]
-            assert item.content == val
+            assert item.content == val, name
 
             try:
                 prev_idx = before.index(val)
-                assert item is children_refs[prev_idx]()
+                assert item is children_refs[prev_idx](), name
             except ValueError:
                 pass
 
-        assert len(after) == len(items.children)
+        assert len(after) == len(items.children), name


### PR DESCRIPTION
When re-rendering a complete PySide UI, the top-level widget is 'removed' from its parent. And when the parent is an application instance, that call will fail. This PR fixes that.

Bonus:
* Fixed some linting issues (newer flake8 found some missing asserts 🙈)
* Fixed a test that was previously not failing because of a missing assert