### PR TITLE
Fix Collagraph instance garbage collection icw Qt event loop

### DIFF
--- a/collagraph/collagraph.py
+++ b/collagraph/collagraph.py
@@ -122,7 +122,7 @@ class Collagraph:
                     loop.call_soon(self.work_loop, deadline)
 
                 self._request = start
-            if self.event_loop_type is EventLoopType.QT:  # pragma: no cover
+            if self.event_loop_type is EventLoopType.QT:
                 from PySide6 import QtCore
 
                 self._qt_timer = QtCore.QTimer()
@@ -134,6 +134,7 @@ class Collagraph:
                 def start(deadline):
                     if not self._qt_first_run:
                         self._qt_timer.timeout.disconnect()
+                    else:
                         self._qt_first_run = False
 
                     weak_self = ref(self)

--- a/collagraph/collagraph.py
+++ b/collagraph/collagraph.py
@@ -3,6 +3,7 @@ import logging
 from queue import SimpleQueue
 import time
 from typing import Any, Callable, Dict, Iterable, List, Optional
+from weakref import ref
 
 from observ import reactive, scheduler, to_raw, watch
 
@@ -134,8 +135,10 @@ class Collagraph:
                     if not self._qt_first_run:
                         self._qt_timer.timeout.disconnect()
                         self._qt_first_run = False
+
+                    weak_self = ref(self)
                     self._qt_timer.timeout.connect(
-                        lambda: self.work_loop(deadline=deadline)
+                        lambda: weak_self() and weak_self().work_loop(deadline=deadline)
                     )
                     self._qt_timer.start()
 

--- a/tests/pyside/test_pyside_renderer.py
+++ b/tests/pyside/test_pyside_renderer.py
@@ -1,3 +1,6 @@
+import gc
+from weakref import ref
+
 from observ import reactive
 import pytest
 
@@ -164,3 +167,22 @@ def test_pyside_event_listeners(qapp, qtbot):
     qtbot.mouseClick(button, QtCore.Qt.LeftButton)
     # The callback should have been removed at this point
     assert clicked == 1
+
+
+def test_cleanup_collagraph_instance(qapp):
+    element = h("widget")
+    gui = Collagraph(
+        renderer=PySideRenderer(autoshow=False),
+        event_loop_type=EventLoopType.QT,
+    )
+    gui.render(element, qapp)
+
+    # Create a weak ref to gui
+    gui_ref = ref(gui)
+    # Set the collagraph instance to None
+    gui = None
+    # Force garbage collection
+    gc.collect()
+
+    # Now we expect the weak ref to be empty
+    assert not gui_ref()


### PR DESCRIPTION
Fix a problem where the `Collagraph` instance would not be garbage collected properly when using the Qt event loop type.