### PR TITLE
Ensure proper parenting of menus and actions

### DIFF
--- a/collagraph/cgx/cgx.py
+++ b/collagraph/cgx/cgx.py
@@ -298,7 +298,12 @@ def convert_node_to_args(node, *, names=None):
             # i, a and b, so we don't want to wrap those names with `_lookup()`
             name_collector = NameCollector()
             for generator in for_tree.generators:
-                name_collector.generic_visit(generator.target)
+                # Apparently, a node visitor does _not_ visit the root node...
+                # So instead, just add the name directly if the root is an ast.Name node
+                if isinstance(generator.target, ast.Name):
+                    name_collector.names.add(generator.target.id)
+                else:
+                    name_collector.generic_visit(generator.target)
 
             local_names = names.union(name_collector.names)
             RewriteName(skip=local_names).visit(for_tree)

--- a/collagraph/cgx/cgx.py
+++ b/collagraph/cgx/cgx.py
@@ -550,3 +550,20 @@ class CGXParser(HTMLParser):
     def handle_data(self, data):
         if data.strip():
             self.stack[-1].data = data.strip()
+
+
+def _print_ast_tree_as_code(tree):  # pragma: no cover
+    """Handy function for debugging an ast tree"""
+    try:
+        import black
+    except ImportError:
+        return
+
+    try:
+        plain_result = ast.unparse(tree)
+        result = black.format_file_contents(
+            plain_result, fast=False, mode=black.mode.Mode()
+        )
+        print(result)  # noqa: T001
+    except TypeError:
+        pass

--- a/collagraph/cgx/cgx.py
+++ b/collagraph/cgx/cgx.py
@@ -569,6 +569,6 @@ def _print_ast_tree_as_code(tree):  # pragma: no cover
         result = black.format_file_contents(
             plain_result, fast=False, mode=black.mode.Mode()
         )
-        print(result)  # noqa: T001
+        print(result)  # noqa: T201
     except TypeError:
         pass

--- a/collagraph/renderers/pyside/objects/menu.py
+++ b/collagraph/renderers/pyside/objects/menu.py
@@ -8,11 +8,13 @@ def insert(self, el, anchor=None):
             self.insertMenu(anchor, el)
         else:
             self.addMenu(el)
+        el.setParent(self)
     elif isinstance(el, QAction):
         if anchor:
             self.insertAction(anchor, el)
         else:
             self.addAction(el)
+        el.setParent(self)
 
 
 def remove(self, el):

--- a/collagraph/renderers/pyside/objects/menu.py
+++ b/collagraph/renderers/pyside/objects/menu.py
@@ -8,13 +8,12 @@ def insert(self, el, anchor=None):
             self.insertMenu(anchor, el)
         else:
             self.addMenu(el)
-        el.setParent(self)
     elif isinstance(el, QAction):
         if anchor:
             self.insertAction(anchor, el)
         else:
             self.addAction(el)
-        el.setParent(self)
+    el.setParent(self)
 
 
 def remove(self, el):
@@ -24,3 +23,4 @@ def remove(self, el):
         el.clear()
         menu_action = el.menuAction()
         self.removeAction(menu_action)
+    el.setParent(None)

--- a/collagraph/renderers/pyside/objects/menubar.py
+++ b/collagraph/renderers/pyside/objects/menubar.py
@@ -2,8 +2,8 @@ from PySide6.QtWidgets import QMenu
 
 
 def insert(self, el: QMenu, anchor: QMenu = None):
-    # TODO: support separators
     if anchor:
         self.insertMenu(anchor, el)
     else:
         self.addMenu(el)
+    el.setParent(self)

--- a/collagraph/renderers/pyside/objects/menubar.py
+++ b/collagraph/renderers/pyside/objects/menubar.py
@@ -7,3 +7,10 @@ def insert(self, el: QMenu, anchor: QMenu = None):
     else:
         self.addMenu(el)
     el.setParent(self)
+
+
+def remove(self, el: QMenu):
+    el.clear()
+    menu_action = el.menuAction()
+    self.removeAction(menu_action)
+    el.setParent(None)

--- a/collagraph/renderers/pyside/objects/window.py
+++ b/collagraph/renderers/pyside/objects/window.py
@@ -14,6 +14,7 @@ def insert(self, el, anchor=None):
         self.addToolBar(el)
     elif isinstance(el, QMenuBar):
         self.setMenuBar(el)
+        el.setParent(self)
     else:
         # Let's assume any other given widget is just the
         # central widget of the QMainWindow

--- a/collagraph/renderers/pyside/utils.py
+++ b/collagraph/renderers/pyside/utils.py
@@ -1,48 +1,29 @@
 from functools import lru_cache
 
 from PySide6 import QtCore, QtGui, QtWidgets
-from PySide6.QtWidgets import (
-    QCheckBox,
-    QComboBox,
-    QDialogButtonBox,
-    QGroupBox,
-    QLabel,
-    QLineEdit,
-    QMainWindow,
-    QMenu,
-    QMenuBar,
-    QProgressBar,
-    QPushButton,
-    QRadioButton,
-    QSlider,
-    QSpinBox,
-    QStatusBar,
-    QTextEdit,
-    QTreeView,
-    QWidget,
-)
 
 
 # Pre-populated cache for types
 TYPE_MAPPING = {
-    "button": QPushButton,
-    "checkbox": QCheckBox,
-    "combobox": QComboBox,
-    "label": QLabel,
-    "lineedit": QLineEdit,
-    "menu": QMenu,
-    "menubar": QMenuBar,
-    "radiobutton": QRadioButton,
-    "dialogbuttonbox": QDialogButtonBox,
-    "groupbox": QGroupBox,
-    "progessbar": QProgressBar,
-    "slider": QSlider,
-    "spinbox": QSpinBox,
-    "statusbar": QStatusBar,
-    "textedit": QTextEdit,
-    "treeview": QTreeView,
-    "widget": QWidget,
-    "window": QMainWindow,
+    "button": QtWidgets.QPushButton,
+    "checkbox": QtWidgets.QCheckBox,
+    "combobox": QtWidgets.QComboBox,
+    "label": QtWidgets.QLabel,
+    "lineedit": QtWidgets.QLineEdit,
+    "menu": QtWidgets.QMenu,
+    "menubar": QtWidgets.QMenuBar,
+    "radiobutton": QtWidgets.QRadioButton,
+    "dialogbuttonbox": QtWidgets.QDialogButtonBox,
+    "groupbox": QtWidgets.QGroupBox,
+    "progessbar": QtWidgets.QProgressBar,
+    "slider": QtWidgets.QSlider,
+    "spinbox": QtWidgets.QSpinBox,
+    "statusbar": QtWidgets.QStatusBar,
+    "textedit": QtWidgets.QTextEdit,
+    "treeview": QtWidgets.QTreeView,
+    "widget": QtWidgets.QWidget,
+    "window": QtWidgets.QMainWindow,
+    "action": QtGui.QAction,
 }
 
 # Default arguments for types that need

--- a/collagraph/renderers/pyside_renderer.py
+++ b/collagraph/renderers/pyside_renderer.py
@@ -73,6 +73,8 @@ REMOVE_MAPPING = sorted_on_class_hierarchy(
         QListView: listview.remove,
         QTableView: listview.remove,
         QTreeView: listview.remove,
+        QMenuBar: menubar.remove,
+        QMenu: menu.remove,
         QStandardItemModel: itemmodel.remove,
     }
 )

--- a/examples/layout-example.py
+++ b/examples/layout-example.py
@@ -46,10 +46,9 @@ def LayoutExample(props):
             h(
                 "QMenu",
                 {"title": "File"},
-                h(
-                    "QAction",
-                    {"text": "Open"},
-                ),
+                h("QAction", {"text": "Open"}),
+                h("QAction", {"separator": True}),
+                h("QMenu", {"title": "Sub"}, h("QAction", {"text": "sub"})),
             ),
         ),
         h(

--- a/tests/cgx/test_cgx_resolve_names.py
+++ b/tests/cgx/test_cgx_resolve_names.py
@@ -4,12 +4,7 @@ from observ import reactive
 def test_resolve_names():
     from tests.data.resolve_names import Example
 
-    state = reactive(
-        {
-            "prop_val": "prop_value",
-            # ""
-        }
-    )
+    state = reactive({"prop_val": "prop_value"})
 
     example = Example(state)
     root = example.render()
@@ -27,7 +22,3 @@ def test_resolve_names():
     assert item.props["value"] == "state_value", item
     item = root.children[5]
     assert item.props["value"] == "value", item
-
-    # assert item.
-    # print(nodes)
-    # assert False

--- a/tests/cgx/test_cgx_resolve_names.py
+++ b/tests/cgx/test_cgx_resolve_names.py
@@ -1,0 +1,33 @@
+from observ import reactive
+
+
+def test_resolve_names():
+    from tests.data.resolve_names import Example
+
+    state = reactive(
+        {
+            "prop_val": "prop_value",
+            # ""
+        }
+    )
+
+    example = Example(state)
+    root = example.render()
+
+    item = root.children[0]
+    assert item.props["value"] == "prop_value", item
+    item = root.children[1]
+    assert item.props["value"] == "state_value", item
+    item = root.children[2]
+    assert item.props["value"] == "value", item
+
+    item = root.children[3]
+    assert item.props["value"] == "prop_value", item
+    item = root.children[4]
+    assert item.props["value"] == "state_value", item
+    item = root.children[5]
+    assert item.props["value"] == "value", item
+
+    # assert item.
+    # print(nodes)
+    # assert False

--- a/tests/cgx/test_cgx_template_directives.py
+++ b/tests/cgx/test_cgx_template_directives.py
@@ -179,6 +179,48 @@ def test_directive_for():
             assert node.children[idx].props["text"] == label
 
 
+def test_directive_for_with_enumerate():
+    from tests.data.directive_for_enumerate import Labels
+
+    state = reactive({"labels": []})
+    component = Labels(state)
+    node = component.render()
+
+    assert node.type == "widget"
+
+    assert len(node.children) == 0
+
+    for labels in (["Foo"], ["Foo", "Bar"], []):
+        state["labels"] = labels
+        node = component.render()
+
+        assert len(node.children) == len(labels)
+        for idx, label in enumerate(labels):
+            assert node.children[idx].props["text"] == label
+
+
+def test_directive_for_elaborate():
+    from tests.data.directive_for_elaborate import Labels
+
+    state = reactive({"labels": [], "suffixes": []})
+    component = Labels(state)
+    node = component.render()
+
+    assert node.type == "widget"
+
+    assert len(node.children) == 0
+
+    for labels, suffixes in ((["Foo"], ["x"]), (["Foo", "Bar"], ["x", "y"]), ([], [])):
+        state["labels"] = labels
+        state["suffixes"] = suffixes
+        node = component.render()
+
+        assert len(node.children) == len(labels)
+        for idx, (label, suffix) in enumerate(zip(labels, suffixes)):
+            assert node.children[idx].props["text"] == label
+            assert node.children[idx].props["suffix"] == suffix
+
+
 def test_directive_on():
     from tests.data.directive_on import Buttons
 

--- a/tests/cgx/test_cgx_template_directives.py
+++ b/tests/cgx/test_cgx_template_directives.py
@@ -210,7 +210,12 @@ def test_directive_for_elaborate():
 
     assert len(node.children) == 0
 
-    for labels, suffixes in ((["Foo"], ["x"]), (["Foo", "Bar"], ["x", "y"]), ([], [])):
+    for labels, suffixes in (
+        (["Foo"], ["x"]),
+        (["Foo", "Bar"], ["x", "y"]),
+        ([], []),
+        (["a", "b", "c", "d"], ["1", "2", "3", "4"]),
+    ):
         state["labels"] = labels
         state["suffixes"] = suffixes
         node = component.render()
@@ -219,6 +224,24 @@ def test_directive_for_elaborate():
         for idx, (label, suffix) in enumerate(zip(labels, suffixes)):
             assert node.children[idx].props["text"] == label
             assert node.children[idx].props["suffix"] == suffix
+
+
+def test_directive_for_nested():
+    from tests.data.directive_for_nested import Labels
+
+    state = reactive({"rows": [["a", "b", "c"], ["d", "e"]]})
+    component = Labels(state)
+    node = component.render()
+
+    assert len(node.children) == 2
+    assert len(node.children[0].children) == 3
+    assert len(node.children[1].children) == 2
+
+    assert node.children[0].children[0].children[0].props["text"] == "0,0: a"
+    assert node.children[0].children[1].children[0].props["text"] == "1,0: b"
+    assert node.children[0].children[2].children[0].props["text"] == "2,0: c"
+    assert node.children[1].children[0].children[0].props["text"] == "0,1: d"
+    assert node.children[1].children[1].children[0].props["text"] == "1,1: e"
 
 
 def test_directive_on():

--- a/tests/data/directive_for_elaborate.cgx
+++ b/tests/data/directive_for_elaborate.cgx
@@ -1,0 +1,18 @@
+<template>
+  <widget>
+    <label
+      v-for="idx, (label, suffix) in enumerate(zip(labels, suffixes))"
+      :key="idx"
+      :text="label"
+      :suffix="suffix"
+    />
+  </widget>
+</template>
+
+<script lang="python">
+import collagraph as cg
+
+
+class Labels(cg.Component):
+    pass
+</script>

--- a/tests/data/directive_for_enumerate.cgx
+++ b/tests/data/directive_for_enumerate.cgx
@@ -1,6 +1,10 @@
 <template>
   <widget>
-    <label v-for="label in labels" :text="label" />
+    <label
+      v-for="idx, label in enumerate(labels)"
+      :key="idx"
+      :text="label"
+    />
   </widget>
 </template>
 

--- a/tests/data/directive_for_nested.cgx
+++ b/tests/data/directive_for_nested.cgx
@@ -1,0 +1,21 @@
+<template>
+  <widget>
+    <template
+      v-for="y, column in enumerate(rows)"
+    >
+      <template
+        v-for="x, data in enumerate(column)"
+      >
+        <label :text="f'{x},{y}: {data}'"></label>
+      </template>
+    </template>
+  </widget>
+</template>
+
+<script lang="python">
+import collagraph as cg
+
+
+class Labels(cg.Component):
+    pass
+</script>

--- a/tests/data/menubar.cgx
+++ b/tests/data/menubar.cgx
@@ -1,0 +1,40 @@
+<template>
+  <window>
+    <menubar
+      v-if="show_menubar"
+      object_name="menubar"
+    >
+      <menu
+        v-if="show_menu"
+        title="Menu"
+        object_name="menu"
+      >
+        <action
+          v-if="show_item"
+          text="Action"
+          object_name="action"
+        />
+        <menu
+          v-if="show_submenu"
+          title="Sub Menu"
+          object_name="submenu"
+        >
+          <action
+            v-if="show_subitem"
+            text="Sub Action"
+            object_name="subaction"
+          />
+        </menu>
+      </menu>
+    </menubar>
+    <widget />
+  </window>
+</template>
+
+<script>
+import collagraph as cg
+
+
+class MenuBarTest(cg.Component):
+    pass
+</script>

--- a/tests/data/resolve_names.cgx
+++ b/tests/data/resolve_names.cgx
@@ -1,0 +1,33 @@
+<template>
+  <root>
+    <!-- Test for binding props['prop_val'] -->
+    <item :value="prop_val" />
+    <!-- Test for binding state['state_val'] -->
+    <item :value="state_val" />
+    <!-- Test for binding self.val -->
+    <item :value="val" />
+
+    <!-- Test for v-if props['prop_val'] -->
+    <item v-if="prop_val" :value="prop_val" />
+    <!-- Test for v-if state['state_val'] -->
+    <item v-if="state_val" :value="state_val" />
+    <!-- Test for v-if self.val -->
+    <item v-if="val" :value="val" />
+  </root>
+</template>
+
+<script>
+import collagraph as cg
+
+
+class Example(cg.Component):
+    def __init__(self, props):
+        super().__init__(props)
+        assert "prop_val" in props
+        self.state["state_val"] = "state_value"
+
+    @property
+    def val(self):
+        return "value"
+
+</script>

--- a/tests/pyside/test_pyside_elements.py
+++ b/tests/pyside/test_pyside_elements.py
@@ -346,8 +346,8 @@ def test_menu_extensively(qapp, qtbot):
         assert menubar is bool(windows[0].findChild(QtWidgets.QMenuBar, "menubar"))
         assert menu is bool(windows[0].findChild(QtWidgets.QMenu, "menu"))
         assert item is bool(windows[0].findChild(QtGui.QAction, "action"))
-        assert submenu is bool(windows[0].findChildren(QtWidgets.QMenu, "submenu"))
-        assert subitem is bool(windows[0].findChildren(QtGui.QAction, "subaction"))
+        assert submenu is bool(windows[0].findChild(QtWidgets.QMenu, "submenu"))
+        assert subitem is bool(windows[0].findChild(QtGui.QAction, "subaction"))
 
     check_items = partial(check, True, True, True, True, True)
     qtbot.waitUntil(check_items, timeout=500)

--- a/tests/pyside/test_pyside_elements.py
+++ b/tests/pyside/test_pyside_elements.py
@@ -2,7 +2,7 @@ from observ import reactive
 import pytest
 
 try:
-    from PySide6 import QtCore, QtWidgets
+    from PySide6 import QtCore, QtGui, QtWidgets
 except ImportError:
     pytest.skip(
         "skip test for PySide6 renderer when not available", allow_module_level=True
@@ -304,12 +304,15 @@ def test_menu(qapp, qtbot):
     gui.render(h(MenuExample, {}), qapp)
 
     def check_file_menu():
-        menus = [
+        windows = [
             widget
             for widget in qapp.topLevelWidgets()
-            if isinstance(widget, QtWidgets.QMenu)
+            if isinstance(widget, QtWidgets.QMainWindow)
         ]
-        assert len(menus) == 1
-        assert menus[0].title() == "File"
+        assert len(windows) == 1
+        menus = windows[0].findChildren(QtWidgets.QMenu)
+        assert any([menu.title() == "File" for menu in menus])
+        actions = windows[0].findChildren(QtGui.QAction)
+        assert any([action.text() == "Open" for action in actions])
 
     qtbot.waitUntil(check_file_menu, timeout=500)


### PR DESCRIPTION
This makes it possible to use `window.findChildren` to look for menus and actions.

Other fixes:
* fix for v-if directives directly following each other
* fix for referencing values by name in v-if directives
* fix #50 