### PR TITLE
Linter support

### DIFF
--- a/collagraph/cgx/cgx.py
+++ b/collagraph/cgx/cgx.py
@@ -106,6 +106,7 @@ def load(path):
         ast.ImportFrom(
             module="collagraph",
             names=[ast.alias(name="create_element", asname="_create_element")],
+            level=0,
         ),
     )
 


### PR DESCRIPTION
Fixes (or rather: enables) #37 (Linting of CGX files).

* Exposes some methods for generating the AST of the CGX file
* Fixes an issue where the `ast.ImportFrom` was missing the `level` argument
* Prevent wrapping of imported names with `_lookup` (should reduce 'imported but unused' warnings)