### PR TITLE
Fix menus on windows

### DIFF
--- a/collagraph/renderers/pyside/objects/menu.py
+++ b/collagraph/renderers/pyside/objects/menu.py
@@ -5,22 +5,24 @@ from PySide6.QtWidgets import QMenu
 def insert(self, el, anchor=None):
     if isinstance(el, QMenu):
         if anchor:
-            self.insertMenu(anchor, el)
+            action = self.insertMenu(anchor, el)
         else:
-            self.addMenu(el)
+            action = self.addMenu(el)
+        action.setParent(self.menuAction())
     elif isinstance(el, QAction):
         if anchor:
             self.insertAction(anchor, el)
         else:
             self.addAction(el)
-    el.setParent(self)
+        el.setParent(self.menuAction())
 
 
 def remove(self, el):
     if isinstance(el, QAction):
         self.removeAction(el)
+        el.setParent(None)
     elif isinstance(el, QMenu):
         el.clear()
         menu_action = el.menuAction()
         self.removeAction(menu_action)
-    el.setParent(None)
+        menu_action.setParent(None)

--- a/collagraph/renderers/pyside/objects/menubar.py
+++ b/collagraph/renderers/pyside/objects/menubar.py
@@ -3,14 +3,21 @@ from PySide6.QtWidgets import QMenu
 
 def insert(self, el: QMenu, anchor: QMenu = None):
     if anchor:
-        self.insertMenu(anchor, el)
+        action = self.insertMenu(anchor, el)
     else:
-        self.addMenu(el)
-    el.setParent(self)
+        action = self.addMenu(el)
+    # Use the window property of the menubar to set
+    # the parent of the action. Instead of keeping
+    # a hierarchy of widgets, instead the hierarchy
+    # is constructed with just the (menu)actions.
+    # Using the widgets works fine on macOS, but causes
+    # problems on Windows where menus would show on top
+    # of each other.
+    action.setParent(self.window())
 
 
 def remove(self, el: QMenu):
     el.clear()
     menu_action = el.menuAction()
     self.removeAction(menu_action)
-    el.setParent(None)
+    menu_action.setParent(None)

--- a/tests/pyside/test_pyside_elements.py
+++ b/tests/pyside/test_pyside_elements.py
@@ -312,8 +312,6 @@ def test_menu(qapp, qtbot):
             if isinstance(widget, QtWidgets.QMainWindow)
         ]
         assert len(windows) == 1
-        menus = windows[0].findChildren(QtWidgets.QMenu)
-        assert any([menu.title() == "File" for menu in menus])
         actions = windows[0].findChildren(QtGui.QAction)
         assert any([action.text() == "Open" for action in actions])
 
@@ -344,9 +342,7 @@ def test_menu_extensively(qapp, qtbot):
         ]
         assert len(windows) == 1
         assert menubar is bool(windows[0].findChild(QtWidgets.QMenuBar, "menubar"))
-        assert menu is bool(windows[0].findChild(QtWidgets.QMenu, "menu"))
         assert item is bool(windows[0].findChild(QtGui.QAction, "action"))
-        assert submenu is bool(windows[0].findChild(QtWidgets.QMenu, "submenu"))
         assert subitem is bool(windows[0].findChild(QtGui.QAction, "subaction"))
 
     check_items = partial(check, True, True, True, True, True)


### PR DESCRIPTION
Building the parent relationship with the widgets results in weird menus on windows. Instead, now the hierarchy is built up with the actions instead, with the root being the window property of the `QMenuBar`.

Before:
<img width="357" alt="image" src="https://user-images.githubusercontent.com/1000968/173576663-36a2472d-deee-4449-a349-c2a65fc9eb51.png">

After:
<img width="356" alt="image" src="https://user-images.githubusercontent.com/1000968/173576476-97537c96-a774-45ca-9432-9bd63bca7040.png">

Note that the widgets are not part of the tree hierarchy anymore, so unlike their actions, the menus can't be found anymore with `findChild`.