### PR TITLE
Improve dialog button box

### DIFF
--- a/collagraph/renderers/pyside/objects/dialogbuttonbox.py
+++ b/collagraph/renderers/pyside/objects/dialogbuttonbox.py
@@ -1,11 +1,29 @@
 from PySide6.QtWidgets import QDialogButtonBox
 
+from .widget import set_attribute as widget_set_attribute
+
 
 def insert(self, el, anchor=None):
-    if hasattr(el, "flag"):
-        self.addButton(getattr(QDialogButtonBox, el.flag))
-        return
-    elif hasattr(el, "role"):
-        self.addButton(el, getattr(QDialogButtonBox, el.role))
+    if hasattr(el, "role"):
+        # Allow the role to be either an actual ButtonRole or a string
+        role = (
+            el.role
+            if isinstance(el.role, QDialogButtonBox.ButtonRole)
+            else getattr(QDialogButtonBox, el.role)
+        )
+        self.addButton(el, role)
         return
     raise NotImplementedError
+
+
+def set_attribute(self, attr, value):
+    if attr == "flags":
+        for flag in value:
+            flag = (
+                flag
+                if isinstance(flag, QDialogButtonBox.StandardButton)
+                else getattr(QDialogButtonBox, flag)
+            )
+            self.addButton(flag)
+    else:
+        widget_set_attribute(self, attr, value)

--- a/collagraph/renderers/pyside/objects/dialogbuttonbox.py
+++ b/collagraph/renderers/pyside/objects/dialogbuttonbox.py
@@ -17,7 +17,7 @@ def insert(self, el, anchor=None):
 
 
 def set_attribute(self, attr, value):
-    if attr == "flags":
+    if attr == "buttons":
         for flag in value:
             flag = (
                 flag

--- a/collagraph/renderers/pyside_renderer.py
+++ b/collagraph/renderers/pyside_renderer.py
@@ -84,6 +84,7 @@ SET_ATTR_MAPPING = sorted_on_class_hierarchy(
         QAction: action.set_attribute,
         QStandardItem: widget.set_attribute,
         QStandardItemModel: widget.set_attribute,
+        QDialogButtonBox: dialogbuttonbox.set_attribute,
     }
 )
 

--- a/examples/layout-example.py
+++ b/examples/layout-example.py
@@ -37,6 +37,18 @@ def LayoutExample(props):
             text = "Line 2, long text:"
         form.append((widget, {"form_label": text, "form_index": i}))
 
+    def accepted():
+        print("accepted")  # noqa: T201
+
+    def rejected():
+        print("rejected")  # noqa: T201
+
+    def select_all():
+        print("select all")  # noqa: T201
+
+    def clicked(btn):
+        print("clicked:", btn)  # noqa: T201
+
     return h(
         "Window",
         {},
@@ -101,9 +113,24 @@ def LayoutExample(props):
             ),
             h(
                 "DialogButtonBox",
-                {},
-                h("Button", {"flag": "Ok"}),
-                h("Button", {"flag": "Cancel"}),
+                {
+                    "on_accepted": accepted,
+                    "on_rejected": rejected,
+                    "on_clicked": clicked,
+                    "flags": ("Ok", "Cancel"),
+                },
+                # Add custom buttons by adding real buttons and specifying a
+                # `role` attribute that will determine where the button will
+                # end up in the botton box.
+                # See `QDialogButtonBox.ButtonRole` enum for more info.
+                h(
+                    "Button",
+                    {
+                        "text": "Select all",
+                        "role": "ResetRole",
+                        "on_clicked": select_all,
+                    },
+                ),
             ),
         ),
     )

--- a/examples/layout-example.py
+++ b/examples/layout-example.py
@@ -117,7 +117,9 @@ def LayoutExample(props):
                     "on_accepted": accepted,
                     "on_rejected": rejected,
                     "on_clicked": clicked,
-                    "flags": ("Ok", "Cancel"),
+                    # Provide a list of standard buttons to add to the dialog box.
+                    # See `QDialogButtonBox.ButtonRole` enum for more info.
+                    "buttons": ("Ok", "Cancel"),
                 },
                 # Add custom buttons by adding real buttons and specifying a
                 # `role` attribute that will determine where the button will

--- a/tests/pyside/test_pyside_elements.py
+++ b/tests/pyside/test_pyside_elements.py
@@ -122,7 +122,7 @@ def test_layouts(qapp, qtbot):
                 ),
                 h(
                     "DialogButtonBox",
-                    {"flags": ("Ok", "Cancel")},
+                    {"buttons": ("Ok", "Cancel")},
                     h("Button", {"text": "Custom", "role": "ActionRole"}),
                 ),
             ),

--- a/tests/pyside/test_pyside_elements.py
+++ b/tests/pyside/test_pyside_elements.py
@@ -122,9 +122,8 @@ def test_layouts(qapp, qtbot):
                 ),
                 h(
                     "DialogButtonBox",
-                    {},
-                    h("Button", {"flag": "Ok"}),
-                    h("Button", {"flag": "Cancel"}),
+                    {"flags": ("Ok", "Cancel")},
+                    h("Button", {"text": "Custom", "role": "ActionRole"}),
                 ),
             ),
         )


### PR DESCRIPTION
Closes #24 .

Instead of creating fake buttons for the 'standard' buttons (such as OK and Cancel), it is now possible to set an attribute on the dialog button box with those buttons.
Update the example (examples/layout-example.py) to show how callbacks work.