### PR TITLE
Support list selection callbacks

### DIFF
--- a/collagraph/renderers/pyside/objects/listview.py
+++ b/collagraph/renderers/pyside/objects/listview.py
@@ -1,10 +1,32 @@
+from typing import Union
+
+from PySide6.QtCore import QItemSelectionModel
 from PySide6.QtGui import QStandardItemModel
 
 
-def insert(self, el: QStandardItemModel, anchor=None):
+def insert(self, el: Union[QStandardItemModel, QItemSelectionModel], anchor=None):
+    if isinstance(el, QStandardItemModel):
+        self.setModel(el)
+    elif isinstance(el, QItemSelectionModel):
+        if model := self.model():
+            el.setModel(model)
+            self.setSelectionModel(el)
+        else:
+            raise RuntimeError(
+                "Can't set a selection model because no item model was set (yet). "
+            )
+    else:
+        raise NotImplementedError(type(el).__name__)
+
     el.setParent(self)
-    self.setModel(el)
 
 
-def remove(self, el):
-    self.setModel(None)
+def remove(self, el: Union[QStandardItemModel, QItemSelectionModel]):
+    if isinstance(el, QStandardItemModel):
+        self.setModel(None)
+    elif isinstance(el, QItemSelectionModel):
+        self.setSelectionModel(None)
+    else:
+        raise NotImplementedError
+
+    el.setParent(None)

--- a/collagraph/renderers/pyside/objects/listview.py
+++ b/collagraph/renderers/pyside/objects/listview.py
@@ -27,6 +27,6 @@ def remove(self, el: Union[QStandardItemModel, QItemSelectionModel]):
     elif isinstance(el, QItemSelectionModel):
         self.setSelectionModel(None)
     else:
-        raise NotImplementedError
+        raise NotImplementedError(type(el).__name__)
 
     el.setParent(None)

--- a/examples/lists-example.py
+++ b/examples/lists-example.py
@@ -26,6 +26,11 @@ def Example(props):
         props["items"][item.row()][0][item.column()] = item.text()
         props["items"][item.row()][1] = item.checkState() == QtCore.Qt.Checked
 
+    def selection_changed(selected, deselected):
+        sel = [(idx.row(), idx.column()) for idx in selected.indexes()]
+        desel = [(idx.row(), idx.column()) for idx in deselected.indexes()]
+        print(desel, "=>", sel)  # noqa: T201
+
     children = []
     for row, (item, check_state) in enumerate(props["items"]):
         for column, text in enumerate(item):
@@ -46,6 +51,10 @@ def Example(props):
         },
         *children
     )
+    selection_model = h(
+        "QItemSelectionModel",
+        {"on_selection_changed": selection_changed},
+    )
 
     return h(
         "Window",
@@ -60,16 +69,27 @@ def Example(props):
                     "QListView",
                     {},
                     item_model,
+                    selection_model,
+                    # NOTE: the order of `item_model` and `selection_model` matters:
+                    # the item model needs to come before the selection model, because
+                    # the selection model needs an item model in order to function and
+                    # `setSelectionModel` call will fail with the following message:
+                    #
+                    #   > QAbstractItemView::setSelectionModel() failed: Trying to set
+                    #   > a selection model, which works on a different model than the
+                    #   > view.
                 ),
                 h(
                     "QTableView",
                     {},
                     item_model,
+                    selection_model,
                 ),
                 h(
                     "QTreeView",
                     {},
                     item_model,
+                    selection_model,
                 ),
             ),
             h(


### PR DESCRIPTION
Closes #25 .

Add support for selection callbacks by making it possible to add `QItemSelectionModel` as a child element to lists (QListView, QTreeView, QTableView).