### PR TITLE
Implement remove_attribute for PygfxRenderer

### DIFF
--- a/collagraph/renderers/pygfx_renderer.py
+++ b/collagraph/renderers/pygfx_renderer.py
@@ -3,6 +3,7 @@ import pygfx as gfx
 from . import Renderer
 
 ELEMENT_TYPE_CACHE = {}
+DEFAULT_ATTR_CACHE = {}
 
 
 class PygfxRenderer(Renderer):
@@ -49,10 +50,32 @@ class PygfxRenderer(Renderer):
             elif attr == "matrix":
                 value = gfx.linalg.Matrix4(*value)
 
+        key = f"{type(obj).__name__}.{attr}"
+        if key not in DEFAULT_ATTR_CACHE:
+            if hasattr(obj, attr):
+                default_value = getattr(obj, attr)
+                if hasattr(default_value, "clone"):
+                    DEFAULT_ATTR_CACHE[key] = default_value.clone()
+                elif hasattr(default_value, "copy"):
+                    DEFAULT_ATTR_CACHE[key] = default_value.copy()
+                else:
+                    DEFAULT_ATTR_CACHE[key] = default_value
+
         setattr(obj, attr, value)
 
     def remove_attribute(self, obj, attr, value):
-        raise NotImplementedError
+        key = f"{type(obj).__name__}.{attr}"
+        if key in DEFAULT_ATTR_CACHE:
+            default_value = DEFAULT_ATTR_CACHE[key]
+            if hasattr(default_value, "clone"):
+                val = default_value.clone()
+            elif hasattr(default_value, "copy"):
+                val = default_value.copy()
+            else:
+                val = default_value
+            setattr(obj, attr, val)
+        else:
+            delattr(obj, attr)
 
     def add_event_listener(self, el, event_type, value):
         el.add_event_handler(value, event_type)


### PR DESCRIPTION
Closes #71 .

Apply the same technique as in PySideRenderer by keeping track of the default values for combinations of type + attribute.