### PR TITLE
Add provide/inject functionality

### DIFF
--- a/collagraph/collagraph.py
+++ b/collagraph/collagraph.py
@@ -239,7 +239,15 @@ class Collagraph:
     def update_class_component(self, fiber: Fiber):
         component = fiber.component or fiber.alternate and fiber.alternate.component
         if not component:
-            component = fiber.type(fiber.props)
+            parent_component = None
+            parent_fiber = fiber.parent
+            while parent_fiber is not None:
+                if parent_fiber.component:
+                    parent_component = parent_fiber.component
+                    break
+                parent_fiber = parent_fiber.parent
+
+            component = fiber.type(props=fiber.props, parent=parent_component)
 
         # Attach the component instance to the fiber
         fiber.component = component
@@ -458,7 +466,7 @@ class Collagraph:
 
             if fiber.mounted:
                 if fiber.component:
-                    fiber.component.element = fiber.child.dom
+                    fiber.component._element = fiber.child.dom
                     fiber.component.mounted()
                 fiber.mounted = False
                 fiber.updated = False

--- a/collagraph/types.py
+++ b/collagraph/types.py
@@ -51,7 +51,7 @@ class Fiber:
     snapshot: Dict = None
     type: Union[str, Callable] = None
     watcher: Any = None
-    component: Any = None
+    component: Any = None  # Component instance
     mounted: bool = False  # Flag for components whether it was mounted
     updated: bool = False  # Flag for components whether any DOM was updated
     unmounted: bool = False  # Flag for components whether it was unmounted

--- a/examples/cgx_component_example.cgx
+++ b/examples/cgx_component_example.cgx
@@ -20,8 +20,8 @@ from collagraph import Component
 
 
 class Example(Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.state["top_to_bottom"] = {
             "type": "box",
             "direction": "TopToBottom",

--- a/examples/component-example.py
+++ b/examples/component-example.py
@@ -13,8 +13,8 @@ class Button(cg.Component):
         "hovered": gfx.MeshPhongMaterial(color=[1.0, 0.2, 0.0]),
     }
 
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.state["pressed"] = False
         self.state["hovered"] = False
         self.state["scale"] = self.props.get("scale", [0.85] * 3)
@@ -54,8 +54,8 @@ class Button(cg.Component):
 
 
 class NumberPad(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.state["columns"] = 4
         self.state["rows"] = 5
 

--- a/examples/dialog_example.cgx
+++ b/examples/dialog_example.cgx
@@ -36,8 +36,8 @@ import collagraph as cg
 
 
 class ListDialog(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.state["selected"] = -1
 
     def accepted(self):

--- a/examples/dialog_example_window.cgx
+++ b/examples/dialog_example_window.cgx
@@ -42,8 +42,8 @@ from examples.dialog_example import ListDialog
 
 
 class Window(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.state["dialog_active"] = False
         self.state['selected_text'] = ""
         self.state['modality'] = "window"

--- a/examples/pygfx-slider-example.py
+++ b/examples/pygfx-slider-example.py
@@ -33,8 +33,8 @@ class Scrubber(cg.Component):
     scrubber_geometry = gfx.sphere_geometry()
     scrubber_material = gfx.MeshPhongMaterial(color=[0.5, 1, 0.5])
 
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._captured = False
         self._sphere = None
         self._mouse_pos = (0, 0)

--- a/examples/todo-example.py
+++ b/examples/todo-example.py
@@ -38,8 +38,8 @@ def TodoList(props):
 
 
 class TodoApp(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.state = reactive(
             {
                 "items": [

--- a/examples/tree_view.cgx
+++ b/examples/tree_view.cgx
@@ -84,8 +84,8 @@ class Model(cg.Component):
 
 
 class TreeView(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         # Adding columns seems to work relatively OK, but removing columns
         # has some problems...
         self.state["columns"] = ["text", "other"]

--- a/examples/tree_widget.cgx
+++ b/examples/tree_widget.cgx
@@ -73,8 +73,8 @@ def Item(props):
 
 
 class TreeWidget(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.state["columns"] = ["text", "other"]
         self.state["items"] = [
             {

--- a/tests/data/app.cgx
+++ b/tests/data/app.cgx
@@ -94,8 +94,8 @@ def quit():
 
 
 class Window(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.state["toggles"] = {
             "show_dock": True,
             "show_dock_title": True,

--- a/tests/data/directive_bind.cgx
+++ b/tests/data/directive_bind.cgx
@@ -12,7 +12,7 @@ import collagraph as cg
 
 
 class Labels(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
-        self.state["label_text"] = props.get("text", "Label")
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.state["label_text"] = self.props.get("text", "Label")
 </script>

--- a/tests/data/directive_bind_context.cgx
+++ b/tests/data/directive_bind_context.cgx
@@ -14,7 +14,7 @@ import collagraph as cg
 
 
 class Labels(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
-        self.state["label_text"] = props.get("text", "Label")
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.state["label_text"] = self.props.get("text", "Label")
 </script>

--- a/tests/data/directive_bind_multiple.cgx
+++ b/tests/data/directive_bind_multiple.cgx
@@ -14,7 +14,7 @@ import collagraph as cg
 
 
 class Labels(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.state["other"] = "bar"
 </script>

--- a/tests/data/directive_bind_state_and_props.cgx
+++ b/tests/data/directive_bind_state_and_props.cgx
@@ -12,7 +12,7 @@ import collagraph as cg
 
 
 class Labels(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
-        self.state["label_text"] = props["text"]
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.state["label_text"] = self.props["text"]
 </script>

--- a/tests/data/directive_on.cgx
+++ b/tests/data/directive_on.cgx
@@ -13,8 +13,8 @@ import collagraph as cg
 
 
 class Buttons(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.state["count"] = 0
 
     def increase(self):

--- a/tests/data/directive_typo.cgx
+++ b/tests/data/directive_typo.cgx
@@ -10,7 +10,7 @@ import collagraph as cg
 
 
 class Label(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.state["text"] = "Foo"
 </script>

--- a/tests/data/resolve_names.cgx
+++ b/tests/data/resolve_names.cgx
@@ -21,9 +21,9 @@ import collagraph as cg
 
 
 class Example(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
-        assert "prop_val" in props
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        assert "prop_val" in self.props
         self.state["state_val"] = "state_value"
 
     @property

--- a/tests/data/shadow_imports.cgx
+++ b/tests/data/shadow_imports.cgx
@@ -9,8 +9,8 @@ import tests
 
 
 class Example(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.state['tests'] = 'foo'
 
     @property

--- a/tests/data/template.cgx
+++ b/tests/data/template.cgx
@@ -16,6 +16,6 @@
 import collagraph as cg
 
 class Template(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 </script>

--- a/tests/data/test_pyside_update.cgx
+++ b/tests/data/test_pyside_update.cgx
@@ -33,8 +33,8 @@ from PySide6 import QtCore, QtWidgets
 
 
 class TreeView(cg.Component):
-    def __init__(self, props):
-        super().__init__(props)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.state["items"] = ["Foo", "Bar", "Bla"]
         self.state["selected"] = []
 

--- a/tests/test_component_events.py
+++ b/tests/test_component_events.py
@@ -7,8 +7,8 @@ def test_components_events():
     child = None
 
     class Parent(cg.Component):
-        def __init__(self, props):
-            super().__init__(props)
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
             nonlocal parent
             parent = self
 
@@ -33,8 +33,8 @@ def test_components_events():
             return cg.h("parent", {}, cg.h(Child, props))
 
     class Child(cg.Component):
-        def __init__(self, props):
-            super().__init__(props)
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
             nonlocal child
             child = self
 

--- a/tests/test_component_provide_inject.py
+++ b/tests/test_component_provide_inject.py
@@ -1,0 +1,74 @@
+import pytest
+
+from collagraph import Collagraph, Component, DictRenderer, EventLoopType, h
+
+
+def test_component_provide_inject():
+    class Child(Component):
+        injected_value = None
+        injected_other = None
+        injected_non_existing = None
+        injected_default = None
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.inject("value", "other", "non_existing", default="baz")
+
+            Child.injected_value = self.value
+            Child.injected_other = self.other
+            Child.injected_non_existing = self.non_existing
+            Child.injected_default = self.default
+
+        def render(self):
+            return h("child")
+
+    class Parent(Component):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            # You can provide values as kwargs
+            self.provide(value="foo")
+            # or as a dictionary
+            self.provide({"other": "bar"})
+
+        def render(self):
+            return h("parent", {}, h(Child))
+
+    gui = Collagraph(DictRenderer(), event_loop_type=EventLoopType.SYNC)
+    container = {"type": "root"}
+    element = h(Parent)
+
+    gui.render(element, container)
+
+    assert Child.injected_value == "foo"
+    assert Child.injected_other == "bar"
+    assert Child.injected_non_existing is None
+    assert Child.injected_default == "baz"
+
+
+def test_component_existing_attribute():
+    class OverwriteExistingAttribute(Component):
+        def mounted(self):
+            # Try to inject a value that is already an attribute
+            # on the component
+            self.inject("parent")
+
+        def render(self):
+            return h("child")
+
+    gui = Collagraph(DictRenderer(), event_loop_type=EventLoopType.SYNC)
+    container = {"type": "root"}
+
+    with pytest.raises(AssertionError):
+        gui.render(h(OverwriteExistingAttribute), container)
+
+    class DoubleInjectionConflict(Component):
+        def mounted(self):
+            # Supply a kwarg with the same key as one of the
+            # values of the args coming before
+            self.inject("value", value="foo")
+
+        def render(self):
+            return h("child")
+
+    with pytest.raises(AssertionError):
+        gui.render(h(DoubleInjectionConflict), container)

--- a/tests/test_component_provide_inject.py
+++ b/tests/test_component_provide_inject.py
@@ -1,23 +1,17 @@
-import pytest
-
 from collagraph import Collagraph, Component, DictRenderer, EventLoopType, h
 
 
 def test_component_provide_inject():
     class Child(Component):
         injected_value = None
-        injected_other = None
         injected_non_existing = None
         injected_default = None
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            self.inject("value", "other", "non_existing", default="baz")
-
-            Child.injected_value = self.value
-            Child.injected_other = self.other
-            Child.injected_non_existing = self.non_existing
-            Child.injected_default = self.default
+            Child.injected_value = self.inject("value")
+            Child.injected_non_existing = self.inject("non_existing")
+            Child.injected_default = self.inject("other", default="bar")
 
         def render(self):
             return h("child")
@@ -25,10 +19,7 @@ def test_component_provide_inject():
     class Parent(Component):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            # You can provide values as kwargs
-            self.provide(value="foo")
-            # or as a dictionary
-            self.provide({"other": "bar"})
+            self.provide(key="value", value="foo")
 
         def render(self):
             return h("parent", {}, h(Child))
@@ -40,35 +31,5 @@ def test_component_provide_inject():
     gui.render(element, container)
 
     assert Child.injected_value == "foo"
-    assert Child.injected_other == "bar"
     assert Child.injected_non_existing is None
-    assert Child.injected_default == "baz"
-
-
-def test_component_existing_attribute():
-    class OverwriteExistingAttribute(Component):
-        def mounted(self):
-            # Try to inject a value that is already an attribute
-            # on the component
-            self.inject("parent")
-
-        def render(self):
-            return h("child")
-
-    gui = Collagraph(DictRenderer(), event_loop_type=EventLoopType.SYNC)
-    container = {"type": "root"}
-
-    with pytest.raises(AssertionError):
-        gui.render(h(OverwriteExistingAttribute), container)
-
-    class DoubleInjectionConflict(Component):
-        def mounted(self):
-            # Supply a kwarg with the same key as one of the
-            # values of the args coming before
-            self.inject("value", value="foo")
-
-        def render(self):
-            return h("child")
-
-    with pytest.raises(AssertionError):
-        gui.render(h(DoubleInjectionConflict), container)
+    assert Child.injected_default == "bar"


### PR DESCRIPTION
Added:

- `parent` attribute on components (used for project/inject)
- `provide` method on component where components can provide values to child components
- `inject` method on component where components can inject provided values from parent components

Vue docs reference: https://vuejs.org/guide/components/provide-inject.html