### PR TITLE
Bump minimum version of pygfx to 0.13

### DIFF
--- a/collagraph/__main__.py
+++ b/collagraph/__main__.py
@@ -35,9 +35,9 @@ def init_collagraph(
 
     if renderer_type == "pygfx":
         import pygfx as gfx
-        from wgpu.gui.auto import WgpuCanvas, run
+        from rendercanvas.auto import RenderCanvas, loop
 
-        canvas = WgpuCanvas(size=(600, 400))
+        canvas = RenderCanvas(size=(600, 400))
         wgpu_renderer = gfx.renderers.WgpuRenderer(canvas)
 
         camera = gfx.PerspectiveCamera(70)
@@ -57,7 +57,7 @@ def init_collagraph(
         gui = cg.Collagraph(renderer=renderer)
         gui.render(component_class, container, state=props)
 
-        run()
+        loop.run()
     elif renderer_type == "pyside":
         from PySide6 import QtWidgets
 

--- a/examples/pygfx/README.md
+++ b/examples/pygfx/README.md
@@ -31,5 +31,5 @@ uv run python examples/pygfx/combined-example.py
 ```
 Shows how to integrate a canvas drawn with Pygfx renderer into a PySide app.
 
-The `PySideRenderer` in `combined-example.py` registers the `WgpuCanvas` class so that the renderer knows which class to create for a `<wgpucanvas />` element.
+The `PySideRenderer` in `combined-example.py` registers the `RenderCanvas` class so that the renderer knows which class to create for a `<render-canvas />` element.
 The `render_widget.cgx` component instantiates a `PygfxRenderer` that renders the point cloud example into a `Scene` object. Note that the amount of points can now be adjusted with the buttons in PySide.

--- a/examples/pygfx/button.cgx
+++ b/examples/pygfx/button.cgx
@@ -10,7 +10,7 @@
 
 <script>
 import pygfx as gfx
-from wgpu.gui.auto import call_later
+from rendercanvas.auto import loop
 
 import collagraph as cg
 
@@ -39,7 +39,7 @@ class Button(cg.Component):
 
     def pad_pressed(self, event):
         self.state["pressed"] = True
-        call_later(2, self.release)
+        loop.call_later(2, self.release)
 
     def release(self):
         self.state["pressed"] = False

--- a/examples/pygfx/combined-example.py
+++ b/examples/pygfx/combined-example.py
@@ -4,7 +4,7 @@ Example of how to render lists, tables and trees.
 
 from observ import reactive
 from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
+from rendercanvas.qt import RenderCanvas
 
 import collagraph as cg
 from examples.pygfx.app_point_cloud import Example
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication()
 
     renderer = cg.PySideRenderer()
-    renderer.register_element("WgpuCanvas", WgpuCanvas)
+    renderer.register_element("RenderCanvas", RenderCanvas)
     gui = cg.Collagraph(renderer=renderer)
 
     state = reactive({"count": 1000})

--- a/examples/pygfx/component-example.py
+++ b/examples/pygfx/component-example.py
@@ -1,11 +1,11 @@
 import pygfx as gfx
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 import collagraph as cg
 from examples.pygfx.numberpad import NumberPad
 
 if __name__ == "__main__":
-    canvas = WgpuCanvas(size=(600, 400))
+    canvas = RenderCanvas(size=(600, 400))
     renderer = gfx.renderers.WgpuRenderer(canvas)
 
     camera = gfx.PerspectiveCamera(60, 16 / 9)
@@ -29,4 +29,4 @@ if __name__ == "__main__":
     gui = cg.Collagraph(renderer=cg.PygfxRenderer())
     gui.renderer.add_on_change_handler(lambda: canvas.request_draw(animate))
     gui.render(NumberPad, container)
-    run()
+    loop.run()

--- a/examples/pygfx/render_widget.cgx
+++ b/examples/pygfx/render_widget.cgx
@@ -1,4 +1,4 @@
-<wgpu-canvas
+<render-canvas
   :minimum_height="400"
   :minimum_width="600"
 />
@@ -13,12 +13,12 @@ import collagraph as cg
 
 class RenderWidget(cg.Component):
     """
-    RenderWidget that shows how to host a wgpu canvas object and
+    RenderWidget that shows how to host a rendercanvas and
     use another collagraph instance to render a 3D scene with Pygfx.
 
-    Note that the wgpu-canvas element needs to be registered
+    Note that the render-canvas element needs to be registered
     with the root collagraph renderer, like this:
-        renderer.register_element("WgpuCanvas", WgpuCanvas)
+        renderer.register_element("RenderCanvas", RenderCanvas)
     """
 
     def mounted(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ collagraph = "collagraph.__main__:run"
 hook-dirs = "collagraph.__pyinstaller:get_hook_dirs"
 
 [project.optional-dependencies]
-pygfx = ["pygfx>=0.9.0"]
+pygfx = ["pygfx>=0.13.0"]
 pyside = ["PySide6>=6.6.2,!=6.8.3,!=6.9.0 ; python_version < '3.15'"]
 
 [dependency-groups]


### PR DESCRIPTION
Convert examples and `__main__` to use `rendercanvas` instead of `wgpu.gui`.