### PR TITLE
Restore support for text expressions

### DIFF
--- a/collagraph/sfc/compiler.py
+++ b/collagraph/sfc/compiler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import logging
+import re
 import sys
 import textwrap
 from collections import defaultdict
@@ -425,6 +426,12 @@ def parse_text_interpolations(text: str) -> list[tuple[bool, str]]:
     return result
 
 
+def normalize_multiline_text(text: str) -> str:
+    if "\n" not in text and "\r" not in text:
+        return text
+    return re.sub(r"(\r?\n)[ \t]+", r"\1", text)
+
+
 def ast_set_text_bind(
     el: str,
     parts: list[tuple[bool, str]],
@@ -683,7 +690,7 @@ def create_collagraph_render_function(
                 )
 
                 # Parse the text content for interpolations
-                text_content = child.content
+                text_content = normalize_multiline_text(child.content)
                 has_interpolation = "{{" in text_content and "}}" in text_content
 
                 if has_interpolation:

--- a/collagraph/sfc/compiler.py
+++ b/collagraph/sfc/compiler.py
@@ -425,6 +425,55 @@ def parse_text_interpolations(text: str) -> list[tuple[bool, str]]:
     return result
 
 
+def ast_set_text_bind(
+    el: str,
+    parts: list[tuple[bool, str]],
+    names: set[str],
+    list_names: list[dict[str, set[str]]],
+) -> ast.Expr:
+    joined_values: list[ast.Constant | ast.FormattedValue] = []
+    for is_expr, part in parts:
+        if is_expr:
+            expression_ast = ast.parse(part, mode="eval")
+            joined_values.append(
+                ast.FormattedValue(
+                    value=expression_ast.body,
+                    conversion=-1,
+                )
+            )
+        elif part:
+            joined_values.append(ast.Constant(value=part))
+
+    source = ast.Expression(
+        body=ast.Call(
+            func=ast.Attribute(
+                value=ast.Name(id=el, ctx=ast.Load()),
+                attr="set_bind",
+                ctx=ast.Load(),
+            ),
+            args=[
+                ast.Constant(value="content"),
+                ast.Lambda(
+                    args=ast.arguments(
+                        posonlyargs=[],
+                        args=[],
+                        kwonlyargs=[],
+                        kw_defaults=[],
+                        defaults=[],
+                    ),
+                    body=ast.JoinedStr(values=joined_values),
+                ),
+            ],
+            keywords=[],
+        )
+    )
+    return ast_named_lambda(
+        source,
+        {"renderer", "new", el, "watch"} | names,
+        list_names,
+    )
+
+
 def safe_tag(tag):
     return tag.replace("-", "_").replace(".", "_")
 
@@ -638,36 +687,21 @@ def create_collagraph_render_function(
                 has_interpolation = "{{" in text_content and "}}" in text_content
 
                 if has_interpolation:
-                    # Create a dynamic bind for text with interpolations
-                    # Build an f-string expression from the text
                     parts = parse_text_interpolations(text_content)
-                    expr_parts = []
-                    for is_expr, part in parts:
-                        if is_expr:
-                            expr_parts.append("{" + part + "}")
-                        else:
-                            # Escape braces and backslashes in static parts for f-string
-                            # First escape backslashes that precede braces to avoid
-                            # invalid escape sequences like \{ in the f-string
-                            escaped = part.replace("\\{", "\\\\{").replace(
-                                "\\}", "\\\\}"
+                    if any(is_expr for is_expr, _ in parts):
+                        result.append(
+                            ast_set_text_bind(
+                                text_el,
+                                parts,
+                                names,
+                                list_names,
                             )
-                            # Then escape standalone braces for f-string syntax
-                            escaped = escaped.replace("{", "{{").replace("}", "}}")
-                            expr_parts.append(escaped)
-                    fstring_content = "".join(expr_parts)
-                    # Create the bind with an f-string
-                    source = ast.parse(
-                        f'{text_el}.set_bind("content", lambda: f"{fstring_content}")',
-                        mode="eval",
-                    )
-                    result.append(
-                        ast_named_lambda(
-                            source,
-                            {"renderer", "new", text_el, "watch"} | names,
-                            list_names,
                         )
-                    )
+                    else:
+                        # Only escaped/unclosed interpolation-like text was found.
+                        result.append(
+                            ast_set_attribute(text_el, "content", text_content)
+                        )
                 else:
                     # Static text - set attribute directly
                     result.append(ast_set_attribute(text_el, "content", text_content))

--- a/tests/data/text/expressions.cgx
+++ b/tests/data/text/expressions.cgx
@@ -8,6 +8,9 @@
       next {{more}}</p>
     <p>First line
       second line</p>
+    <p>Complex "{{content}}"
+      middle \{{literal}} {{more}}
+        tail {{content}}/{{more}}</p>
     <p>Split<!--by a comment--> and split by <span>an</span> element</p>
   </div>
 </template>

--- a/tests/data/text/expressions.cgx
+++ b/tests/data/text/expressions.cgx
@@ -3,6 +3,9 @@
     <p>Static content</p>
     <p>Dynamic {{content}}</p>
     <p>Even {{more}} dyna{}mic\{} {{content}}</p>
+    <p>Quote "{{content}}" and slash \\ {{more}}</p>
+    <p>Line "{{content}}"
+next {{more}}</p>
     <p>Split<!--by a comment--> and split by <span>an</span> element</p>
   </div>
 </template>

--- a/tests/data/text/expressions.cgx
+++ b/tests/data/text/expressions.cgx
@@ -5,7 +5,9 @@
     <p>Even {{more}} dyna{}mic\{} {{content}}</p>
     <p>Quote "{{content}}" and slash \\ {{more}}</p>
     <p>Line "{{content}}"
-next {{more}}</p>
+      next {{more}}</p>
+    <p>First line
+      second line</p>
     <p>Split<!--by a comment--> and split by <span>an</span> element</p>
   </div>
 </template>

--- a/tests/test_text_expressions.py
+++ b/tests/test_text_expressions.py
@@ -1,11 +1,9 @@
-import pytest
 from observ import reactive
 
 from collagraph import Collagraph, DictRenderer, EventLoopType
 from collagraph.renderers.dict_renderer import format_dict
 
 
-@pytest.mark.xfail
 def test_text_elements():
     from tests.data.text.expressions import Example
 

--- a/tests/test_text_expressions.py
+++ b/tests/test_text_expressions.py
@@ -17,35 +17,49 @@ def test_text_elements():
 
     assert result["type"] == "div"
 
-    static_p, dynamic_p, multiple_p, split_p = result["children"]
+    static_p, dynamic_p, multiple_p, quoted_p, multiline_p, split_p = result["children"]
 
     assert static_p["type"] == "p"
     assert dynamic_p["type"] == "p"
     assert multiple_p["type"] == "p"
+    assert quoted_p["type"] == "p"
+    assert multiline_p["type"] == "p"
     assert split_p["type"] == "p"
 
     assert (
-        "children" in static_p and "children" in dynamic_p and "children" in multiple_p
+        "children" in static_p
+        and "children" in dynamic_p
+        and "children" in multiple_p
+        and "children" in quoted_p
+        and "children" in multiline_p
     ), format_dict(container)
 
     assert (
         len(static_p["children"])
         == len(dynamic_p["children"])
         == len(multiple_p["children"])
+        == len(quoted_p["children"])
+        == len(multiline_p["children"])
         == 1
     ), format_dict(container)
 
-    static, dynamic, multiple = (
+    static, dynamic, multiple, quoted, multiline = (
         static_p["children"][0],
         dynamic_p["children"][0],
         multiple_p["children"][0],
+        quoted_p["children"][0],
+        multiline_p["children"][0],
     )
     assert static["type"] == "TEXT_ELEMENT"
     assert dynamic["type"] == "TEXT_ELEMENT"
     assert multiple["type"] == "TEXT_ELEMENT"
+    assert quoted["type"] == "TEXT_ELEMENT"
+    assert multiline["type"] == "TEXT_ELEMENT"
     assert static["attrs"]["content"] == "Static content"
     assert dynamic["attrs"]["content"] == "Dynamic foo"
     assert multiple["attrs"]["content"] == r"Even bar dyna{}mic\{} foo"
+    assert quoted["attrs"]["content"] == 'Quote "foo" and slash \\\\ bar'
+    assert multiline["attrs"]["content"] == 'Line "foo"\nnext bar'
 
     assert len(split_p["children"]) == 4
     assert split_p["children"][0]["type"] == "TEXT_ELEMENT"

--- a/tests/test_text_expressions.py
+++ b/tests/test_text_expressions.py
@@ -17,13 +17,22 @@ def test_text_elements():
 
     assert result["type"] == "div"
 
-    static_p, dynamic_p, multiple_p, quoted_p, multiline_p, split_p = result["children"]
+    (
+        static_p,
+        dynamic_p,
+        multiple_p,
+        quoted_p,
+        multiline_p,
+        static_multiline_p,
+        split_p,
+    ) = result["children"]
 
     assert static_p["type"] == "p"
     assert dynamic_p["type"] == "p"
     assert multiple_p["type"] == "p"
     assert quoted_p["type"] == "p"
     assert multiline_p["type"] == "p"
+    assert static_multiline_p["type"] == "p"
     assert split_p["type"] == "p"
 
     assert (
@@ -32,6 +41,7 @@ def test_text_elements():
         and "children" in multiple_p
         and "children" in quoted_p
         and "children" in multiline_p
+        and "children" in static_multiline_p
     ), format_dict(container)
 
     assert (
@@ -40,26 +50,30 @@ def test_text_elements():
         == len(multiple_p["children"])
         == len(quoted_p["children"])
         == len(multiline_p["children"])
+        == len(static_multiline_p["children"])
         == 1
     ), format_dict(container)
 
-    static, dynamic, multiple, quoted, multiline = (
+    static, dynamic, multiple, quoted, multiline, static_multiline = (
         static_p["children"][0],
         dynamic_p["children"][0],
         multiple_p["children"][0],
         quoted_p["children"][0],
         multiline_p["children"][0],
+        static_multiline_p["children"][0],
     )
     assert static["type"] == "TEXT_ELEMENT"
     assert dynamic["type"] == "TEXT_ELEMENT"
     assert multiple["type"] == "TEXT_ELEMENT"
     assert quoted["type"] == "TEXT_ELEMENT"
     assert multiline["type"] == "TEXT_ELEMENT"
+    assert static_multiline["type"] == "TEXT_ELEMENT"
     assert static["attrs"]["content"] == "Static content"
     assert dynamic["attrs"]["content"] == "Dynamic foo"
     assert multiple["attrs"]["content"] == r"Even bar dyna{}mic\{} foo"
     assert quoted["attrs"]["content"] == 'Quote "foo" and slash \\\\ bar'
     assert multiline["attrs"]["content"] == 'Line "foo"\nnext bar'
+    assert static_multiline["attrs"]["content"] == "First line\nsecond line"
 
     assert len(split_p["children"]) == 4
     assert split_p["children"][0]["type"] == "TEXT_ELEMENT"

--- a/tests/test_text_expressions.py
+++ b/tests/test_text_expressions.py
@@ -24,6 +24,7 @@ def test_text_elements():
         quoted_p,
         multiline_p,
         static_multiline_p,
+        complex_multiline_p,
         split_p,
     ) = result["children"]
 
@@ -33,6 +34,7 @@ def test_text_elements():
     assert quoted_p["type"] == "p"
     assert multiline_p["type"] == "p"
     assert static_multiline_p["type"] == "p"
+    assert complex_multiline_p["type"] == "p"
     assert split_p["type"] == "p"
 
     assert (
@@ -42,6 +44,7 @@ def test_text_elements():
         and "children" in quoted_p
         and "children" in multiline_p
         and "children" in static_multiline_p
+        and "children" in complex_multiline_p
     ), format_dict(container)
 
     assert (
@@ -51,16 +54,26 @@ def test_text_elements():
         == len(quoted_p["children"])
         == len(multiline_p["children"])
         == len(static_multiline_p["children"])
+        == len(complex_multiline_p["children"])
         == 1
     ), format_dict(container)
 
-    static, dynamic, multiple, quoted, multiline, static_multiline = (
+    (
+        static,
+        dynamic,
+        multiple,
+        quoted,
+        multiline,
+        static_multiline,
+        complex_multiline,
+    ) = (
         static_p["children"][0],
         dynamic_p["children"][0],
         multiple_p["children"][0],
         quoted_p["children"][0],
         multiline_p["children"][0],
         static_multiline_p["children"][0],
+        complex_multiline_p["children"][0],
     )
     assert static["type"] == "TEXT_ELEMENT"
     assert dynamic["type"] == "TEXT_ELEMENT"
@@ -68,12 +81,17 @@ def test_text_elements():
     assert quoted["type"] == "TEXT_ELEMENT"
     assert multiline["type"] == "TEXT_ELEMENT"
     assert static_multiline["type"] == "TEXT_ELEMENT"
+    assert complex_multiline["type"] == "TEXT_ELEMENT"
     assert static["attrs"]["content"] == "Static content"
     assert dynamic["attrs"]["content"] == "Dynamic foo"
     assert multiple["attrs"]["content"] == r"Even bar dyna{}mic\{} foo"
     assert quoted["attrs"]["content"] == 'Quote "foo" and slash \\\\ bar'
     assert multiline["attrs"]["content"] == 'Line "foo"\nnext bar'
     assert static_multiline["attrs"]["content"] == "First line\nsecond line"
+    assert (
+        complex_multiline["attrs"]["content"]
+        == 'Complex "foo"\nmiddle {{literal}} bar\ntail foo/bar'
+    )
 
     assert len(split_p["children"]) == 4
     assert split_p["children"][0]["type"] == "TEXT_ELEMENT"


### PR DESCRIPTION
Support for text expressions was lost when #119 was merged. This should fix it.
However, with the current supported renderers there is not much use to it.