### PR TITLE
Add CI job to test PyInstaller hooks and update hook to dynamically generate python code from cgx files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,22 @@ jobs:
         env:
           QT_QPA_PLATFORM: offscreen
 
+  pyinstaller:
+    name: Test PyInstaller hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
+      - name: Install dependencies
+        run: uv sync
+      - name: Test PyInstaller hooks
+        run: bash tests/pyinstaller/test_pyinstaller.sh
+
   build:
     name: Build and test wheel
     runs-on: ubuntu-latest
@@ -91,7 +107,7 @@ jobs:
   publish:
     name: Publish to Github and Pypi
     runs-on: ubuntu-latest
-    needs: [lint, test, build]
+    needs: [lint, test, build, pyinstaller]
     if: success() && startsWith(github.ref, 'refs/tags/v')
     environment:
       name: pypi

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ __pycache__
 .coverage
 dist
 build
+*.spec
 uv.lock
 .venv

--- a/collagraph/__pyinstaller/hook-collagraph.py
+++ b/collagraph/__pyinstaller/hook-collagraph.py
@@ -1,48 +1,96 @@
 import ast
-import logging
+import atexit
 from pathlib import Path
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.lib.modulegraph.modulegraph import DependencyInfo, MissingModule
 
-from collagraph.sfc.compiler import get_script_ast
+from collagraph.sfc.compiler import construct_ast, get_script_ast
 from collagraph.sfc.parser import CGXParser
 
-logger = logging.getLogger(__name__)
+# Keep track of generated files so they can be cleaned up
+_generated_files: list[Path] = []
+
+
+def _cleanup_generated_files():
+    for path in _generated_files:
+        path.unlink(missing_ok=True)
+
+
+atexit.register(_cleanup_generated_files)
 
 
 def hook(hook_api):
     collagraph_uses = hook_api.analysis.graph.get_code_using("collagraph")
 
     hidden_imports = set()
-    datas = []
     cgx_modules = set()
+
     for package, code in collagraph_uses.items():
         source_dir = Path(code.co_filename).parent
 
         # Collect CGX files and their imports from the source directory
         cgx_files = list(source_dir.glob("**/*.cgx"))
         hidden_imports |= collect_hidden_imports(cgx_files)
-        cgx_modules |= {path.stem for path in cgx_files}
 
-        # Try package-based collection for installed packages
-        package_datas = collect_data_files(package, includes=["**/*.cgx"])
-        if package_datas:
-            datas += package_datas
-        else:
-            # For standalone scripts, collect CGX files directly
-            for cgx_path in cgx_files:
-                relative = cgx_path.relative_to(source_dir)
-                dest_dir = str(relative.parent)
-                if dest_dir == ".":
-                    dest_dir = ""
-                datas.append((str(cgx_path), dest_dir or "."))
+        # Pre-compile each CGX file to Python source so that
+        # PyInstaller can bundle them as regular Python modules,
+        # removing the need to bundle .cgx files and compile them
+        # at runtime
+        for cgx_path in cgx_files:
+            module_name = cgx_path.stem
+            tree, _name = construct_ast(cgx_path)
+            python_source = ast.unparse(tree)
 
-    # Filter out imports that correspond to CGX modules, since those
-    # are loaded at runtime by the CGX import hook, not by PyInstaller
+            # Write compiled module next to the CGX file so
+            # PyInstaller can discover it on its existing search path
+            py_path = cgx_path.with_suffix(".py")
+            if not py_path.exists():
+                py_path.write_text(python_source, encoding="utf-8")
+                _generated_files.append(py_path)
+            cgx_modules.add(module_name)
+
+    # Filter out imports that correspond to CGX modules, since
+    # they are now available as pre-compiled Python modules
     hidden_imports -= cgx_modules
 
+    graph = hook_api.analysis.graph
+
+    # Remove any MissingModule nodes for CGX modules that were
+    # already marked as missing during initial analysis (before
+    # the compiled .py files existed).
+    # removeNode() calls hide_node() which moves the node to
+    # hidden_nodes. Graph.add_node() silently ignores nodes in
+    # hidden_nodes, so we must also delete from hidden_nodes to
+    # allow import_hook to re-add the module as a SourceModule.
+    for name in cgx_modules:
+        node = graph.find_node(name)
+        if isinstance(node, MissingModule):
+            graph.removeNode(node)
+            if name in graph.graph.hidden_nodes:
+                del graph.graph.hidden_nodes[name]
+
+    # Import CGX modules via the module graph and create edges
+    # to the collagraph node so they are included in the bundle.
+    collagraph_node = graph.find_node("collagraph")
+    for name in cgx_modules:
+        try:
+            nodes = graph.import_hook(name, collagraph_node)
+            for node in nodes:
+                graph._updateReference(
+                    collagraph_node,
+                    node,
+                    edge_data=DependencyInfo(
+                        conditional=False,
+                        fromlist=False,
+                        function=False,
+                        tryexcept=False,
+                    ),
+                )
+        except ImportError:
+            pass
+
+    # Add remaining hidden imports (non-CGX Python modules)
     hook_api.add_imports(*hidden_imports)
-    hook_api.add_datas(datas)
 
 
 def collect_hidden_imports(cgx_files):

--- a/collagraph/__pyinstaller/hook-collagraph.py
+++ b/collagraph/__pyinstaller/hook-collagraph.py
@@ -1,4 +1,5 @@
 import ast
+import logging
 from pathlib import Path
 
 from PyInstaller.utils.hooks import collect_data_files
@@ -6,26 +7,47 @@ from PyInstaller.utils.hooks import collect_data_files
 from collagraph.sfc.compiler import get_script_ast
 from collagraph.sfc.parser import CGXParser
 
+logger = logging.getLogger(__name__)
+
 
 def hook(hook_api):
     collagraph_uses = hook_api.analysis.graph.get_code_using("collagraph")
 
     hidden_imports = set()
     datas = []
+    cgx_modules = set()
     for package, code in collagraph_uses.items():
-        filename = Path(code.co_filename)
-        hidden_imports |= collect_hidden_imports(filename.parent)
-        datas += collect_data_files(package, includes=["**/*.cgx"])
+        source_dir = Path(code.co_filename).parent
+
+        # Collect CGX files and their imports from the source directory
+        cgx_files = list(source_dir.glob("**/*.cgx"))
+        hidden_imports |= collect_hidden_imports(cgx_files)
+        cgx_modules |= {path.stem for path in cgx_files}
+
+        # Try package-based collection for installed packages
+        package_datas = collect_data_files(package, includes=["**/*.cgx"])
+        if package_datas:
+            datas += package_datas
+        else:
+            # For standalone scripts, collect CGX files directly
+            for cgx_path in cgx_files:
+                relative = cgx_path.relative_to(source_dir)
+                dest_dir = str(relative.parent)
+                if dest_dir == ".":
+                    dest_dir = ""
+                datas.append((str(cgx_path), dest_dir or "."))
+
+    # Filter out imports that correspond to CGX modules, since those
+    # are loaded at runtime by the CGX import hook, not by PyInstaller
+    hidden_imports -= cgx_modules
 
     hook_api.add_imports(*hidden_imports)
     hook_api.add_datas(datas)
 
 
-def collect_hidden_imports(folder):
-    folder = Path(folder)
-
+def collect_hidden_imports(cgx_files):
     hidden_imports = set()
-    for path in folder.glob("**/*.cgx"):
+    for path in cgx_files:
         template = path.read_text(encoding="utf-8")
         # Parse the file component into a tree of Node instances
         parser = CGXParser()
@@ -34,8 +56,7 @@ def collect_hidden_imports(folder):
         # Get the AST from the script tag
         script_tree = get_script_ast(parser, path)
 
-        # Find a list of imported names (or aliases, if any)
-        # Those names don't have to be wrapped by `_lookup`
+        # Find a list of imported module names
         imported_names = ImportsCollector()
         imported_names.visit(script_tree)
 
@@ -49,9 +70,8 @@ class ImportsCollector(ast.NodeVisitor):
         self.names = set()
 
     def visit_ImportFrom(self, node):
-        for alias in node.names:
-            self.names.add(".".join([node.module, alias.name]))
-        self.names.add(node.module)
+        if node.module:
+            self.names.add(node.module)
 
     def visit_Import(self, node):
         for alias in node.names:

--- a/collagraph/sfc/importer.py
+++ b/collagraph/sfc/importer.py
@@ -66,5 +66,8 @@ class CGXPathFinder(MetaPathFinder):
                 return spec
 
 
-# Add cgx path finder at the end of the list of finders
-sys.meta_path.append(CGXPathFinder())
+# Add cgx path finder at the end of the list of finders.
+# Skip when running as a frozen PyInstaller bundle, since CGX files
+# are pre-compiled to Python modules by the PyInstaller hook.
+if not getattr(sys, "frozen", False):
+    sys.meta_path.append(CGXPathFinder())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ pyside-dev = [
 "examples/pygfx/*.py" = ["I001"]  # unsorted-imports
 "examples/pyside/flow_layout.py" = ["N802"]  # invalid-function-name
 "tests/*" = ["N806", "N802"]  # non-lowercase-variable-in-function, invalid-function-name
+"tests/pyinstaller/*" = ["I001", "T20"]  # unsorted-imports, flake8-print
 "tests/pyside/test_*.py" = ["E402"]  # module-import-not-at-top-of-file
 
 [tool.ruff.lint]

--- a/tests/pyinstaller/expected_output.json
+++ b/tests/pyinstaller/expected_output.json
@@ -1,0 +1,28 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "list",
+      "children": [
+        {
+          "type": "item",
+          "attrs": {
+            "label": "[todo] Buy groceries"
+          }
+        },
+        {
+          "type": "item",
+          "attrs": {
+            "label": "[done] Write tests"
+          }
+        },
+        {
+          "type": "item",
+          "attrs": {
+            "label": "[todo] Deploy app"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/pyinstaller/test_pyinstaller.sh
+++ b/tests/pyinstaller/test_pyinstaller.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+APP_DIR="$SCRIPT_DIR/todo_app"
+EXPECTED="$SCRIPT_DIR/expected_output.json"
+
+echo "==> Installing pyinstaller..."
+uv pip install pyinstaller
+
+echo "==> Building todo_app with PyInstaller..."
+cd "$APP_DIR"
+uv run pyinstaller \
+    --noconfirm \
+    --log-level WARN \
+    --onefile \
+    --name todo_app \
+    app.py
+
+echo "==> Running bundled application..."
+OUTPUT=$(./dist/todo_app)
+
+echo "==> Comparing output..."
+EXPECTED_CONTENT=$(cat "$EXPECTED")
+
+if [ "$OUTPUT" = "$EXPECTED_CONTENT" ]; then
+    echo "==> PyInstaller test PASSED"
+else
+    echo "==> PyInstaller test FAILED"
+    echo ""
+    echo "Expected:"
+    echo "$EXPECTED_CONTENT"
+    echo ""
+    echo "Got:"
+    echo "$OUTPUT"
+    exit 1
+fi

--- a/tests/pyinstaller/todo_app/app.py
+++ b/tests/pyinstaller/todo_app/app.py
@@ -1,0 +1,25 @@
+import json
+
+import collagraph as cg
+
+from todo_list import TodoList
+
+container = {"type": "root"}
+gui = cg.Collagraph(
+    renderer=cg.DictRenderer(),
+    event_loop_type=cg.EventLoopType.SYNC,
+)
+gui.render(TodoList, container)
+
+
+def serialize(obj):
+    """Serialize the rendered dict tree to a JSON-compatible structure."""
+    if isinstance(obj, dict):
+        return {k: serialize(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [serialize(v) for v in obj]
+    return obj
+
+
+result = serialize(container)
+print(json.dumps(result, indent=2))

--- a/tests/pyinstaller/todo_app/app.py
+++ b/tests/pyinstaller/todo_app/app.py
@@ -11,15 +11,4 @@ gui = cg.Collagraph(
 )
 gui.render(TodoList, container)
 
-
-def serialize(obj):
-    """Serialize the rendered dict tree to a JSON-compatible structure."""
-    if isinstance(obj, dict):
-        return {k: serialize(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [serialize(v) for v in obj]
-    return obj
-
-
-result = serialize(container)
-print(json.dumps(result, indent=2))
+print(json.dumps(container, indent=2))

--- a/tests/pyinstaller/todo_app/helpers.py
+++ b/tests/pyinstaller/todo_app/helpers.py
@@ -1,0 +1,3 @@
+def format_label(text, done):
+    status = "done" if done else "todo"
+    return f"[{status}] {text}"

--- a/tests/pyinstaller/todo_app/todo_item.cgx
+++ b/tests/pyinstaller/todo_app/todo_item.cgx
@@ -1,8 +1,6 @@
-<template>
-  <item :label="format_label(props['text'], props['done'])" />
-</template>
+<item :label="format_label(props['text'], props['done'])" />
 
-<script lang="python">
+<script>
 import collagraph as cg
 from helpers import format_label
 
@@ -10,3 +8,4 @@ from helpers import format_label
 class TodoItem(cg.Component):
     pass
 </script>
+

--- a/tests/pyinstaller/todo_app/todo_item.cgx
+++ b/tests/pyinstaller/todo_app/todo_item.cgx
@@ -1,0 +1,12 @@
+<template>
+  <item :label="format_label(props['text'], props['done'])" />
+</template>
+
+<script lang="python">
+import collagraph as cg
+from helpers import format_label
+
+
+class TodoItem(cg.Component):
+    pass
+</script>

--- a/tests/pyinstaller/todo_app/todo_list.cgx
+++ b/tests/pyinstaller/todo_app/todo_list.cgx
@@ -1,15 +1,13 @@
-<template>
-  <list>
-    <TodoItem
-      v-for="todo in state['todos']"
-      :key="todo['id']"
-      :text="todo['text']"
-      :done="todo['done']"
-    />
-  </list>
-</template>
+<list>
+  <TodoItem
+    v-for="todo in state['todos']"
+    :done="todo['done']"
+    :key="todo['id']"
+    :text="todo['text']"
+  />
+</list>
 
-<script lang="python">
+<script>
 import collagraph as cg
 from todo_item import TodoItem
 
@@ -22,3 +20,4 @@ class TodoList(cg.Component):
             {"id": 3, "text": "Deploy app", "done": False},
         ]
 </script>
+

--- a/tests/pyinstaller/todo_app/todo_list.cgx
+++ b/tests/pyinstaller/todo_app/todo_list.cgx
@@ -1,0 +1,24 @@
+<template>
+  <list>
+    <TodoItem
+      v-for="todo in state['todos']"
+      :key="todo['id']"
+      :text="todo['text']"
+      :done="todo['done']"
+    />
+  </list>
+</template>
+
+<script lang="python">
+import collagraph as cg
+from todo_item import TodoItem
+
+
+class TodoList(cg.Component):
+    def init(self):
+        self.state["todos"] = [
+            {"id": 1, "text": "Buy groceries", "done": False},
+            {"id": 2, "text": "Write tests", "done": True},
+            {"id": 3, "text": "Deploy app", "done": False},
+        ]
+</script>


### PR DESCRIPTION
Add a todo list test app with nested CGX components and a Python helper module to verify that PyInstaller correctly bundles all dependencies. The test script can be run locally with `bash tests/pyinstaller/test_pyinstaller.sh`. This script is also used in CI to test the PyInstaller hook.

Update the hook to dynamically compile all cgx files and include the resulting py files in the build. This replaces bundling of the cgx files as data files and having to compile them at run-time.

PyInstaller will also compile the python files to bytecode (pyc) so this supersedes #135. That PR has some problems such as making sure pyc files are updated when collagraph source code changes.
Closes #128 by making PyInstaller handle the generated python code.