### PR TITLE
Bump version to 9.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "collagraph"
-version = "0.9.2"
+version = "0.9.3"
 description = "Reactive user interfaces"
 authors = [
     { name = "Berend Klein Haneveld", email = "berendkleinhaneveld@gmail.com" },


### PR DESCRIPTION
This release includes the following:

* Update pyinstaller hooks to pre-compile all templates so it doesn't need to include the templates at all (#171 )