### PR TITLE
Write compiled AST to temp file when CGX_DEBUG is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ Instead of using a python file as an entry point to run components, you can run 
 uv run collagraph examples/pyside/counter.cgx
 ```
 
+To inspect the Python code that is compiled for a component, use the `--show-code` flag:
+
+```sh
+uv run collagraph --show-code examples/pyside/counter.cgx
+```
+
 For more examples, please take a look at the [examples folder](examples).
 
 Currently there are two renderers:

--- a/collagraph/__main__.py
+++ b/collagraph/__main__.py
@@ -81,6 +81,14 @@ def init_collagraph(
         breakpoint()  # noqa: T100
 
 
+def show_code(component_path: Path):
+    """Pretty print the Python code that is compiled for a component."""
+    from collagraph.sfc import print_source
+    from collagraph.sfc.compiler import generate_source
+
+    print_source(generate_source(component_path), component_path)
+
+
 def existing_component_file(value):
     path = Path(value)
     if not path.exists():
@@ -134,7 +142,16 @@ def run():
         action="store_true",
         help="Enable hot reloading (reload on file changes)",
     )
+    parser.add_argument(
+        "--show-code",
+        action="store_true",
+        help="Pretty print the compiled Python code for the component and exit",
+    )
     args = parser.parse_args()
+
+    if args.show_code:
+        show_code(args.component)
+        return
 
     init_collagraph(args.renderer, args.component, args.state, args.hot_reload)
 

--- a/collagraph/sfc/__init__.py
+++ b/collagraph/sfc/__init__.py
@@ -1,6 +1,6 @@
 from collagraph import Component
 
-from .compiler import construct_ast
+from .compiler import DEBUG, construct_ast, format_code
 
 
 def load(path, namespace=None):
@@ -43,7 +43,19 @@ def load_from_string(template, path=None, namespace=None):
     tree, name = construct_ast(path=path, template=template)
 
     # Compile the tree into a code object (module)
-    code = compile(tree, filename=str(path), mode="exec")
+    # When CGX_DEBUG is set, write the AST to a temporary Python file
+    # and reparse it so that debuggers can step through the generated
+    # source with correct line numbers.
+    filename = str(path)
+    if DEBUG:  # pragma: no cover
+        debug_file, source = _write_debug_file(tree, path)
+        if debug_file:
+            import ast
+
+            filename = str(debug_file)
+            tree = ast.parse(source, filename=filename)
+
+    code = compile(tree, filename=filename, mode="exec")
     # Execute the code as module and pass a dictionary that will capture
     # the global and local scope of the module
     if namespace is None:
@@ -60,3 +72,45 @@ def load_from_string(template, path=None, namespace=None):
     namespace["__component_class"] = component_class
     namespace["__component_name"] = name
     return component_class, namespace
+
+
+def _write_debug_file(tree, path):  # pragma: no cover
+    """Write the compiled AST to a temporary Python file for debugging.
+
+    Returns a tuple of (path, formatted_source), or (None, None) if writing fails.
+    """
+    import ast
+    import logging
+    import tempfile
+    from pathlib import Path
+
+    logger = logging.getLogger(__name__)
+
+    try:
+        plain_result = ast.unparse(tree)
+        formatted = format_code(plain_result)
+
+        # Create a meaningful filename based on the source .cgx file
+        source_name = Path(path).stem if path else "template"
+        debug_file = Path(tempfile.mktemp(prefix=f"cgx_{source_name}_", suffix=".py"))
+        debug_file.write_text(formatted, encoding="utf-8")
+        logger.debug("CGX debug file written to: %s", debug_file)
+
+        try:
+            from rich.console import Console
+            from rich.syntax import Syntax
+
+            console = Console()
+            syntax = Syntax(formatted, "python")
+            console.print(f"#---{path}---")
+            console.print(syntax)
+            console.print(f"[dim]Debug file: {debug_file}[/dim]")
+        except ImportError:
+            print(f"#---{path}---")  # noqa: T201
+            print(formatted)  # noqa: T201
+            print(f"Debug file: {debug_file}")  # noqa: T201
+
+        return debug_file, formatted
+    except Exception as e:
+        logger.warning("Could not write AST debug file", exc_info=e)
+        return None, None

--- a/collagraph/sfc/__init__.py
+++ b/collagraph/sfc/__init__.py
@@ -83,7 +83,27 @@ def load_from_string(template, path=None, namespace=None):
     return component_class, namespace
 
 
-def _write_debug_file(tree, path):  # pragma: no cover
+def print_source(source, path, footer=None):
+    """Pretty print (Python) source with rich, when available,
+    falling back to plain print otherwise.
+    """
+    try:
+        from rich.console import Console
+        from rich.syntax import Syntax
+
+        console = Console()
+        console.print(f"#---{path}---")
+        console.print(Syntax(source, "python", line_numbers=True))
+        if footer:
+            console.print(f"[dim]{footer}[/dim]")
+    except ImportError:
+        print(f"#---{path}---")  # noqa: T201
+        print(source)  # noqa: T201
+        if footer:
+            print(footer)  # noqa: T201
+
+
+def _write_debug_file(tree, path):
     """Write the compiled AST to a temporary Python file for debugging.
 
     Returns a tuple of (path, formatted_source), or (None, None) if writing fails.
@@ -96,8 +116,7 @@ def _write_debug_file(tree, path):  # pragma: no cover
     logger = logging.getLogger(__name__)
 
     try:
-        plain_result = ast.unparse(tree)
-        formatted = format_code(plain_result)
+        formatted = format_code(ast.unparse(tree))
 
         # Create a meaningful filename based on the source .cgx file
         source_name = Path(path).stem if path else "template"
@@ -112,19 +131,7 @@ def _write_debug_file(tree, path):  # pragma: no cover
         debug_file = Path(fh.name)
         logger.debug("CGX debug file written to: %s", debug_file)
 
-        try:
-            from rich.console import Console
-            from rich.syntax import Syntax
-
-            console = Console()
-            syntax = Syntax(formatted, "python")
-            console.print(f"#---{path}---")
-            console.print(syntax)
-            console.print(f"[dim]Debug file: {debug_file}[/dim]")
-        except ImportError:
-            print(f"#---{path}---")  # noqa: T201
-            print(formatted)  # noqa: T201
-            print(f"Debug file: {debug_file}")  # noqa: T201
+        print_source(formatted, path, footer=f"Debug file: {debug_file}")
 
         return debug_file, formatted
     except Exception as e:

--- a/collagraph/sfc/__init__.py
+++ b/collagraph/sfc/__init__.py
@@ -101,8 +101,15 @@ def _write_debug_file(tree, path):  # pragma: no cover
 
         # Create a meaningful filename based on the source .cgx file
         source_name = Path(path).stem if path else "template"
-        debug_file = Path(tempfile.mktemp(prefix=f"cgx_{source_name}_", suffix=".py"))
-        debug_file.write_text(formatted, encoding="utf-8")
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            prefix=f"cgx_{source_name}_",
+            suffix=".py",
+            delete=False,
+        ) as fh:
+            fh.write(formatted)
+        debug_file = Path(fh.name)
         logger.debug("CGX debug file written to: %s", debug_file)
 
         try:

--- a/collagraph/sfc/__init__.py
+++ b/collagraph/sfc/__init__.py
@@ -47,13 +47,22 @@ def load_from_string(template, path=None, namespace=None):
     # and reparse it so that debuggers can step through the generated
     # source with correct line numbers.
     filename = str(path)
-    if DEBUG:  # pragma: no cover
+    if DEBUG:
         debug_file, source = _write_debug_file(tree, path)
         if debug_file:
             import ast
+            import logging
 
-            filename = str(debug_file)
-            tree = ast.parse(source, filename=filename)
+            try:
+                debug_tree = ast.parse(source, filename=str(debug_file))
+            except SyntaxError as e:
+                logging.getLogger(__name__).warning(
+                    "Could not parse debug source, falling back to original tree",
+                    exc_info=e,
+                )
+            else:
+                filename = str(debug_file)
+                tree = debug_tree
 
     code = compile(tree, filename=filename, mode="exec")
     # Execute the code as module and pass a dictionary that will capture

--- a/collagraph/sfc/compiler.py
+++ b/collagraph/sfc/compiler.py
@@ -1003,9 +1003,11 @@ def check_parsed_tree(node: Element):
         )
 
 
-def format_code(code):  # pragma: no cover
+def format_code(code):
     """
     Format the given code string with ruff
+
+    Returns the code unchanged when formatting fails.
     """
     from subprocess import run
 
@@ -1015,4 +1017,7 @@ def format_code(code):  # pragma: no cover
         encoding="utf-8",
         capture_output=True,
     )
+    if result.returncode != 0 or not result.stdout:
+        logger.warning("Could not format code with ruff: %s", result.stderr)
+        return code
     return result.stdout

--- a/collagraph/sfc/compiler.py
+++ b/collagraph/sfc/compiler.py
@@ -94,11 +94,6 @@ def construct_ast(path, template=None):
     # method to fix any `lineno` and `col_offset` attributes of the nodes
     ast.fix_missing_locations(script_tree)
 
-    if DEBUG:  # pragma: no cover
-        try:
-            _print_ast_tree_as_code(script_tree, path)
-        except Exception as e:
-            logger.warning("Could not unparse AST", exc_info=e)
     return script_tree, component_def.name
 
 
@@ -1006,19 +1001,6 @@ def check_parsed_tree(node: Element):
         raise ValueError(
             f"Expected exactly 1 script tag, found: {number_of_script_tags_in_root}"
         )
-
-
-def _print_ast_tree_as_code(tree, path):  # pragma: no cover
-    """Handy function for debugging an ast tree"""
-    from rich.console import Console
-    from rich.syntax import Syntax
-
-    plain_result = ast.unparse(tree)
-    formatted = format_code(plain_result)
-    console = Console()
-    syntax = Syntax(formatted, "python")
-    console.print(f"#---{path}---")
-    console.print(syntax)
 
 
 def format_code(code):  # pragma: no cover

--- a/collagraph/sfc/compiler.py
+++ b/collagraph/sfc/compiler.py
@@ -1011,13 +1011,26 @@ def format_code(code):
     """
     from subprocess import run
 
-    result = run(
-        ["ruff", "format", "-"],
-        input=code,
-        encoding="utf-8",
-        capture_output=True,
-    )
+    try:
+        result = run(
+            ["ruff", "format", "-"],
+            input=code,
+            encoding="utf-8",
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        logger.warning("Could not format code: ruff not found")
+        return code
     if result.returncode != 0 or not result.stdout:
         logger.warning("Could not format code with ruff: %s", result.stderr)
         return code
     return result.stdout
+
+
+def generate_source(path, template=None):
+    """
+    Return the formatted Python source that is generated
+    for the .cgx file at the given path.
+    """
+    tree, _ = construct_ast(path=path, template=template)
+    return format_code(ast.unparse(tree))

--- a/tests/test_sfc_debug.py
+++ b/tests/test_sfc_debug.py
@@ -1,7 +1,10 @@
 """Tests for the CGX_DEBUG support code paths."""
 
+import tempfile
+
 import collagraph.sfc
-from collagraph.sfc.compiler import format_code
+from collagraph.sfc import _write_debug_file
+from collagraph.sfc.compiler import construct_ast, format_code
 
 SIMPLE_TEMPLATE = """
 <item />
@@ -42,3 +45,22 @@ def test_load_falls_back_when_debug_source_is_broken(monkeypatch, tmp_path):
 
     component, _ = collagraph.sfc.load_from_string(SIMPLE_TEMPLATE)
     assert component.__name__ == "Item"
+
+
+def test_write_debug_file_avoids_mktemp(monkeypatch):
+    # tempfile.mktemp is deprecated and racy (the file is created
+    # after the name is picked); the debug file should be created
+    # atomically instead.
+    def forbidden(*args, **kwargs):
+        raise AssertionError("tempfile.mktemp is deprecated and insecure")
+
+    monkeypatch.setattr(tempfile, "mktemp", forbidden)
+
+    tree, _ = construct_ast(path="example.cgx", template=SIMPLE_TEMPLATE)
+    debug_file, source = _write_debug_file(tree, "example.cgx")
+
+    assert debug_file is not None
+    assert debug_file.name.startswith("cgx_example_")
+    assert debug_file.suffix == ".py"
+    assert debug_file.read_text(encoding="utf-8") == source
+    debug_file.unlink()

--- a/tests/test_sfc_debug.py
+++ b/tests/test_sfc_debug.py
@@ -1,0 +1,15 @@
+"""Tests for the CGX_DEBUG support code paths."""
+
+from collagraph.sfc.compiler import format_code
+
+
+def test_format_code_formats_valid_code():
+    assert format_code("x=1") == "x = 1\n"
+
+
+def test_format_code_returns_input_when_ruff_fails():
+    # Invalid syntax makes `ruff format` exit non-zero with empty
+    # stdout; format_code should fall back to the unformatted input
+    # instead of returning an empty string.
+    broken = "def broken(:"
+    assert format_code(broken) == broken

--- a/tests/test_sfc_debug.py
+++ b/tests/test_sfc_debug.py
@@ -1,6 +1,18 @@
 """Tests for the CGX_DEBUG support code paths."""
 
+import collagraph.sfc
 from collagraph.sfc.compiler import format_code
+
+SIMPLE_TEMPLATE = """
+<item />
+
+<script>
+import collagraph as cg
+
+class Item(cg.Component):
+    pass
+</script>
+"""
 
 
 def test_format_code_formats_valid_code():
@@ -13,3 +25,20 @@ def test_format_code_returns_input_when_ruff_fails():
     # instead of returning an empty string.
     broken = "def broken(:"
     assert format_code(broken) == broken
+
+
+def test_load_falls_back_when_debug_source_is_broken(monkeypatch, tmp_path):
+    # When the debug file somehow ends up with unparsable source,
+    # loading should fall back to the original tree instead of
+    # raising a SyntaxError.
+    broken = "def broken(:"
+    debug_file = tmp_path / "broken.py"
+    debug_file.write_text(broken, encoding="utf-8")
+
+    monkeypatch.setattr(collagraph.sfc, "DEBUG", True)
+    monkeypatch.setattr(
+        collagraph.sfc, "_write_debug_file", lambda tree, path: (debug_file, broken)
+    )
+
+    component, _ = collagraph.sfc.load_from_string(SIMPLE_TEMPLATE)
+    assert component.__name__ == "Item"

--- a/tests/test_show_code.py
+++ b/tests/test_show_code.py
@@ -1,0 +1,29 @@
+"""Tests for the --show-code CLI feature."""
+
+import sys
+from pathlib import Path
+
+from collagraph.__main__ import run
+from collagraph.sfc.compiler import generate_source
+
+EXAMPLE_CGX = Path(__file__).parent / "data" / "example.cgx"
+
+
+def test_generate_source():
+    source = generate_source(EXAMPLE_CGX)
+
+    assert "class Example(cg.Component):" in source
+    assert "def render(self, renderer):" in source
+    # The generated source should be valid Python
+    compile(source, "example.py", mode="exec")
+
+
+def test_cli_show_code(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["collagraph", "--show-code", str(EXAMPLE_CGX)])
+
+    run()
+
+    captured = capsys.readouterr()
+    assert "example.cgx" in captured.out
+    assert "class Example" in captured.out
+    assert "def render" in captured.out


### PR DESCRIPTION
When CGX_DEBUG is enabled, write the formatted generated Python source to a temporary file and use it as the compile filename. The formatted source is reparsed so line numbers in the code object match the file on disk, allowing debuggers (pdb, PyCharm, VS Code) to step through the generated render methods with correct source display.

## Robustness fixes

Since the debug path now affects what actually gets compiled and executed, a few failure modes are handled explicitly (each with a regression test):

- `format_code` checks ruff's exit code (and handles a missing ruff binary) and falls back to the unformatted code, instead of silently returning an empty string that would be loaded as an empty module.
- When the debug source fails to reparse, loading falls back to the original AST with a warning, so `CGX_DEBUG` can never break a load that would otherwise succeed.
- The debug file is created atomically with `NamedTemporaryFile(delete=False)` instead of the deprecated and racy `tempfile.mktemp`.

## New: `collagraph --show-code`

Since the console printing of generated code was refactored out of `construct_ast`, there is now a dedicated way to inspect the compiled Python for a component:

```sh
uv run collagraph --show-code examples/pyside/counter.cgx
```

It pretty prints the generated source with rich (plain print fallback when rich is unavailable) and exits. The printing logic is shared between the CLI and the CGX_DEBUG output via new `generate_source`/`print_source` helpers.
