### PR TITLE
Preserve PySide TreeView selection/expansion across keyed reorders

### DIFF
--- a/collagraph/renderers/pyside/objects/itemmodel.py
+++ b/collagraph/renderers/pyside/objects/itemmodel.py
@@ -1,6 +1,74 @@
-from PySide6.QtGui import QStandardItemModel
+from PySide6.QtCore import QItemSelectionModel
+from PySide6.QtGui import QStandardItem, QStandardItemModel
+from PySide6.QtWidgets import QListView, QTableView, QTreeView
 
 from ... import PySideRenderer
+
+
+def _get_view_from_model(model: QStandardItemModel):
+    parent = model.parent()
+    if isinstance(parent, (QTreeView, QListView, QTableView)):
+        return parent
+    return None
+
+
+def _snapshot_item_state(
+    item: QStandardItem,
+    model: QStandardItemModel,
+    view,
+) -> list[tuple[QStandardItem, bool, bool]]:
+    snapshot: list[tuple[QStandardItem, bool, bool]] = []
+
+    def walk(it: QStandardItem) -> None:
+        index = model.indexFromItem(it)
+        selected = view.selectionModel().isSelected(index)
+        expanded = isinstance(view, QTreeView) and view.isExpanded(index)
+        snapshot.append((it, expanded, selected))
+        for row in range(it.rowCount()):
+            child = it.child(row)
+            if child:
+                walk(child)
+
+    walk(item)
+    return snapshot
+
+
+def _apply_item_selection(
+    model: QStandardItemModel,
+    view,
+    item: QStandardItem,
+    selected: bool,
+) -> None:
+    selection_model = view.selectionModel()
+    index = model.indexFromItem(item)
+    flags = QItemSelectionModel.SelectionFlag.Rows
+    if selected:
+        flags |= QItemSelectionModel.SelectionFlag.Select
+    else:
+        flags |= QItemSelectionModel.SelectionFlag.Deselect
+    selection_model.select(index, flags)
+
+
+def _apply_item_expanded(
+    model: QStandardItemModel,
+    view,
+    item: QStandardItem,
+    expanded: bool,
+) -> None:
+    if isinstance(view, QTreeView):
+        index = model.indexFromItem(item)
+        view.setExpanded(index, expanded)
+
+
+def _restore_item_state(
+    snapshot: list[tuple[QStandardItem, bool, bool]],
+    model: QStandardItemModel,
+    view,
+) -> None:
+    for item, expanded, _selected in snapshot:
+        _apply_item_expanded(model, view, item, expanded)
+    for item, _expanded, selected in snapshot:
+        _apply_item_selection(model, view, item, selected)
 
 
 @PySideRenderer.register_insert(QStandardItemModel)
@@ -16,11 +84,29 @@ def insert(self, el, anchor=None):
             self.insertRow(index.row(), el)
         else:
             self.appendRow(el)
+
+        view = _get_view_from_model(self)
+        if view:
+            if hasattr(el, "_state_snapshot"):
+                _restore_item_state(el._state_snapshot, self, view)
+                del el._state_snapshot
+
+            if hasattr(el, "_expanded"):
+                _apply_item_expanded(self, view, el, el._expanded)
+                delattr(el, "_expanded")
+
+            if hasattr(el, "_selected"):
+                _apply_item_selection(self, view, el, el._selected)
+                delattr(el, "_selected")
     else:
         raise NotImplementedError(type(self).__name__)
 
 
 @PySideRenderer.register_remove(QStandardItemModel)
 def remove(self, el):
+    view = _get_view_from_model(self)
+    if view:
+        el._state_snapshot = _snapshot_item_state(el, self, view)
+
     index = self.indexFromItem(el)
     self.takeRow(index.row())

--- a/collagraph/renderers/pyside/objects/standarditem.py
+++ b/collagraph/renderers/pyside/objects/standarditem.py
@@ -1,7 +1,96 @@
+from PySide6.QtCore import QItemSelectionModel
 from PySide6.QtGui import QStandardItem
+from PySide6.QtWidgets import QListView, QTableView, QTreeView
 
 from ... import PySideRenderer
 from .qobject import set_attribute as qobject_set_attribute
+
+
+def _get_view_from_item(item: QStandardItem):
+    model = item.model()
+    if not model:
+        return None
+
+    parent = model.parent()
+    if isinstance(parent, (QTreeView, QListView, QTableView)):
+        return parent
+    return None
+
+
+def _snapshot_item_state(item: QStandardItem):
+    model = item.model()
+    view = _get_view_from_item(item)
+    if not (model and view):
+        return None
+
+    snapshot: list[tuple[QStandardItem, bool, bool]] = []
+
+    def walk(it: QStandardItem) -> None:
+        index = model.indexFromItem(it)
+        selected = view.selectionModel().isSelected(index)
+        expanded = isinstance(view, QTreeView) and view.isExpanded(index)
+        snapshot.append((it, expanded, selected))
+        for row in range(it.rowCount()):
+            child = it.child(row)
+            if child:
+                walk(child)
+
+    walk(item)
+    return snapshot
+
+
+def _apply_item_selection(item: QStandardItem, selected: bool) -> None:
+    model = item.model()
+    view = _get_view_from_item(item)
+    if not (model and view):
+        item._selected = selected
+        return
+
+    selection_model = view.selectionModel()
+    index = model.indexFromItem(item)
+    flags = QItemSelectionModel.SelectionFlag.Rows
+    if selected:
+        flags |= QItemSelectionModel.SelectionFlag.Select
+    else:
+        flags |= QItemSelectionModel.SelectionFlag.Deselect
+    selection_model.select(index, flags)
+
+
+def _apply_item_expanded(item: QStandardItem, expanded: bool) -> None:
+    model = item.model()
+    view = _get_view_from_item(item)
+    if not (model and isinstance(view, QTreeView)):
+        item._expanded = expanded
+        return
+
+    index = model.indexFromItem(item)
+    view.setExpanded(index, expanded)
+
+
+def _restore_item_state(item: QStandardItem) -> None:
+    if not hasattr(item, "_state_snapshot"):
+        return
+
+    model = item.model()
+    view = _get_view_from_item(item)
+    if not (model and view):
+        return
+
+    snapshot = item._state_snapshot
+    for it, expanded, _selected in snapshot:
+        if isinstance(view, QTreeView):
+            index = model.indexFromItem(it)
+            view.setExpanded(index, expanded)
+    for it, _expanded, selected in snapshot:
+        index = model.indexFromItem(it)
+        flags = QItemSelectionModel.SelectionFlag.Rows
+        if selected:
+            flags |= QItemSelectionModel.SelectionFlag.Select
+        else:
+            flags |= QItemSelectionModel.SelectionFlag.Deselect
+        view.selectionModel().select(index, flags)
+
+    del item._state_snapshot
 
 
 @PySideRenderer.register_insert(QStandardItem)
@@ -19,13 +108,29 @@ def insert(self, el, anchor=None):
                 break
         if index is None:
             return
+        if el.row() >= 0 and el.parent() == self:
+            self.takeRow(el.row())
         self.insertRow(index, el)
     else:
         self.appendRow(el)
 
+    _restore_item_state(el)
+
+    if hasattr(el, "_expanded"):
+        _apply_item_expanded(el, el._expanded)
+        delattr(el, "_expanded")
+
+    if hasattr(el, "_selected"):
+        _apply_item_selection(el, el._selected)
+        delattr(el, "_selected")
+
 
 @PySideRenderer.register_remove(QStandardItem)
 def remove(self, el):
+    snapshot = _snapshot_item_state(el)
+    if snapshot is not None:
+        el._state_snapshot = snapshot
+
     if hasattr(el, "model_index"):
         # Only support removal of rows for now
         row, _column = getattr(el, "model_index")
@@ -48,6 +153,14 @@ def set_attribute(self, attr, value):
         model.blockSignals(True)
 
     try:
+        match attr:
+            case "selected":
+                _apply_item_selection(self, value)
+                return
+            case "expanded":
+                _apply_item_expanded(self, value)
+                return
+
         if attr == "model_index" and model:
             index = model.indexFromItem(self)
             row, column = value

--- a/examples/pyside/keyed_tree_demo.cgx
+++ b/examples/pyside/keyed_tree_demo.cgx
@@ -1,0 +1,135 @@
+<!--
+  Run with:
+  uv run collagraph examples/pyside/keyed_tree_demo.cgx
+
+  Try this sequence:
+  1) Expand a couple of parents and select a parent/child in the tree.
+  2) Click Reverse or Shuffle.
+  3) Observe that expanded + selection state stays with the moved items.
+-->
+<widget>
+  <label text="Keyed TreeView Reorder Demo" />
+  <label text="Manually expand/select items, then reorder parents." />
+
+  <widget :layout="{'type': 'Box', 'direction': 'LeftToRight'}">
+    <button
+      text="Reverse Parents"
+      @clicked="reverse_parents"
+    />
+    <button
+      text="Shuffle Parents"
+      @clicked="shuffle_parents"
+    />
+    <button
+      text="Print UI State"
+      @clicked="print_ui_state"
+    />
+  </widget>
+
+  <treeview object-name="tree">
+    <itemmodel>
+      <standarditem
+        v-for="parent in items"
+        :key="parent['id']"
+        :text="parent['text']"
+      >
+        <standarditem
+          v-for="child in parent['children']"
+          :key="child['id']"
+          :text="child['text']"
+        />
+      </standarditem>
+    </itemmodel>
+  </treeview>
+
+  <label :text="status_text()" />
+</widget>
+
+<script>
+import random
+
+import collagraph as cg
+from PySide6 import QtWidgets
+
+
+class App(cg.Component):
+    def init(self):
+        self.state["items"] = [
+            {
+                "id": 1,
+                "text": "Parent 1",
+                "children": [
+                    {"id": 11, "text": "Child 1.1"},
+                    {"id": 12, "text": "Child 1.2"},
+                ],
+            },
+            {
+                "id": 2,
+                "text": "Parent 2",
+                "children": [
+                    {"id": 21, "text": "Child 2.1"},
+                    {"id": 22, "text": "Child 2.2"},
+                ],
+            },
+            {
+                "id": 3,
+                "text": "Parent 3",
+                "children": [
+                    {"id": 31, "text": "Child 3.1"},
+                ],
+            },
+            {
+                "id": 4,
+                "text": "Parent 4",
+                "children": [
+                    {"id": 41, "text": "Child 4.1"},
+                    {"id": 42, "text": "Child 4.2"},
+                    {"id": 43, "text": "Child 4.3"},
+                ],
+            },
+        ]
+
+    def reverse_parents(self):
+        self.state["items"] = list(reversed(self.state["items"]))
+
+    def shuffle_parents(self):
+        items = list(self.state["items"])
+        random.shuffle(items)
+        self.state["items"] = items
+
+    def status_text(self):
+        parent_count = len(self.state["items"])
+        child_count = sum(len(parent["children"]) for parent in self.state["items"])
+        return f"Parents: {parent_count} | Children: {child_count}"
+
+    def print_ui_state(self):
+        tree = self.element.findChild(QtWidgets.QTreeView, "tree")
+        if not tree:
+            print("TreeView not found")
+            return
+
+        model = tree.model()
+        selection_model = tree.selectionModel()
+
+        selected = []
+        expanded = []
+
+        for row in range(model.rowCount()):
+            parent_item = model.item(row)
+            parent_index = model.indexFromItem(parent_item)
+
+            if selection_model.isSelected(parent_index):
+                selected.append(parent_item.text())
+            if tree.isExpanded(parent_index):
+                expanded.append(parent_item.text())
+
+            for child_row in range(parent_item.rowCount()):
+                child_item = parent_item.child(child_row)
+                child_index = model.indexFromItem(child_item)
+                if selection_model.isSelected(child_index):
+                    selected.append(child_item.text())
+
+        print(f"Order: {[parent['text'] for parent in self.state['items']]}")
+        print(f"Selected: {selected}")
+        print(f"Expanded parents: {expanded}")
+</script>

--- a/tests/pyside/test_treeview_keyed_selection.py
+++ b/tests/pyside/test_treeview_keyed_selection.py
@@ -1,0 +1,291 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from observ import reactive
+from PySide6 import QtWidgets
+from PySide6.QtCore import QItemSelectionModel
+
+import collagraph as cg
+
+
+def test_treeview_keyed_reorder_preserves_bound_selection_and_expanded(
+    qtbot, parse_source
+):
+    element, _ = parse_source(
+        """
+        <treeview>
+          <itemmodel>
+            <standarditem
+              v-for="item in items"
+              :key="item['id']"
+              :selected="item['selected']"
+              :expanded="item['expanded']"
+              :text="item['name']"
+            >
+              <standarditem :text="'Child of ' + item['name']" />
+            </standarditem>
+          </itemmodel>
+        </treeview>
+
+        <script>
+        import collagraph as cg
+
+        class Element(cg.Component):
+            pass
+        </script>
+        """
+    )
+
+    renderer = cg.PySideRenderer(autoshow=False)
+    gui = cg.Collagraph(renderer=renderer)
+
+    state = reactive(
+        {
+            "items": [
+                {"id": "a", "name": "Item A", "selected": True, "expanded": True},
+                {
+                    "id": "b",
+                    "name": "Item B",
+                    "selected": False,
+                    "expanded": False,
+                },
+                {"id": "c", "name": "Item C", "selected": False, "expanded": True},
+            ]
+        }
+    )
+
+    container = renderer.create_element("widget")
+    gui.render(element, container, state=state)
+
+    tree_view = None
+    model = None
+
+    def find_tree_and_model():
+        nonlocal tree_view, model
+        tree_view = container.findChild(QtWidgets.QTreeView)
+        assert tree_view is not None
+        model = tree_view.model()
+        assert model is not None
+        assert model.rowCount() == 3
+
+    qtbot.waitUntil(find_tree_and_model, timeout=500)
+
+    state["items"] = [state["items"][2], state["items"][1], state["items"][0]]
+
+    qtbot.wait(200)
+
+    def check_after_reorder():
+        selection_model = tree_view.selectionModel()
+
+        index_c = model.index(0, 0)
+        index_b = model.index(1, 0)
+        index_a = model.index(2, 0)
+
+        assert model.itemFromIndex(index_c).text() == "Item C"
+        assert selection_model.isSelected(index_c) is False
+        assert tree_view.isExpanded(index_c) is True
+
+        assert model.itemFromIndex(index_b).text() == "Item B"
+        assert selection_model.isSelected(index_b) is False
+        assert tree_view.isExpanded(index_b) is False
+
+        assert model.itemFromIndex(index_a).text() == "Item A"
+        assert selection_model.isSelected(index_a) is True
+        assert tree_view.isExpanded(index_a) is True
+
+    qtbot.waitUntil(check_after_reorder, timeout=1000)
+
+
+def test_treeview_keyed_reorder_preserves_manual_parent_selection(qtbot, parse_source):
+    element, _ = parse_source(
+        """
+        <treeview>
+          <itemmodel>
+            <standarditem
+              v-for="item in items"
+              :key="item['id']"
+              :text="item['text']"
+            />
+          </itemmodel>
+        </treeview>
+
+        <script>
+        import collagraph as cg
+
+        class Element(cg.Component):
+            pass
+        </script>
+        """
+    )
+
+    renderer = cg.PySideRenderer(autoshow=False)
+    gui = cg.Collagraph(renderer=renderer)
+
+    state = reactive(
+        {
+            "items": [
+                {"id": 1, "text": "Item 1"},
+                {"id": 2, "text": "Item 2"},
+                {"id": 3, "text": "Item 3"},
+                {"id": 4, "text": "Item 4"},
+            ]
+        }
+    )
+
+    container = renderer.create_element("widget")
+    gui.render(element, container, state=state)
+
+    tree_view = None
+    model = None
+
+    def find_tree_and_model():
+        nonlocal tree_view, model
+        tree_view = container.findChild(QtWidgets.QTreeView)
+        assert tree_view is not None
+        model = tree_view.model()
+        assert model is not None
+        assert model.rowCount() == 4
+
+    qtbot.waitUntil(find_tree_and_model, timeout=500)
+
+    selection_model = tree_view.selectionModel()
+    selected_index = model.index(0, 0)
+    selection_model.select(
+        selected_index,
+        QItemSelectionModel.SelectionFlag.Select
+        | QItemSelectionModel.SelectionFlag.Rows,
+    )
+
+    qtbot.waitUntil(lambda: selection_model.isSelected(model.index(0, 0)), timeout=500)
+
+    state["items"] = [
+        state["items"][2],
+        state["items"][3],
+        state["items"][0],
+        state["items"][1],
+    ]
+
+    qtbot.wait(200)
+
+    def check_after_reorder():
+        assert model.item(0).text() == "Item 3"
+        assert model.item(1).text() == "Item 4"
+        assert model.item(2).text() == "Item 1"
+        assert model.item(3).text() == "Item 2"
+
+        new_index = model.index(2, 0)
+        assert selection_model.isSelected(new_index) is True
+        assert len(selection_model.selectedRows()) == 1
+
+    qtbot.waitUntil(check_after_reorder, timeout=1000)
+
+
+def test_treeview_keyed_reorder_preserves_manual_child_selection(qtbot, parse_source):
+    element, _ = parse_source(
+        """
+        <treeview>
+          <itemmodel>
+            <standarditem
+              v-for="item in items"
+              :key="item['id']"
+              :text="item['text']"
+              :expanded="item['expanded']"
+            >
+              <standarditem
+                v-for="child in item['children']"
+                :key="child['id']"
+                :text="child['text']"
+              />
+            </standarditem>
+          </itemmodel>
+        </treeview>
+
+        <script>
+        import collagraph as cg
+
+        class Element(cg.Component):
+            pass
+        </script>
+        """
+    )
+
+    renderer = cg.PySideRenderer(autoshow=False)
+    gui = cg.Collagraph(renderer=renderer)
+
+    state = reactive(
+        {
+            "items": [
+                {
+                    "id": 1,
+                    "text": "Parent 1",
+                    "expanded": True,
+                    "children": [
+                        {"id": 11, "text": "Child 1.1"},
+                        {"id": 12, "text": "Child 1.2"},
+                    ],
+                },
+                {
+                    "id": 2,
+                    "text": "Parent 2",
+                    "expanded": True,
+                    "children": [{"id": 21, "text": "Child 2.1"}],
+                },
+                {
+                    "id": 3,
+                    "text": "Parent 3",
+                    "expanded": True,
+                    "children": [
+                        {"id": 31, "text": "Child 3.1"},
+                        {"id": 32, "text": "Child 3.2"},
+                    ],
+                },
+            ]
+        }
+    )
+
+    container = renderer.create_element("widget")
+    gui.render(element, container, state=state)
+
+    tree_view = None
+    model = None
+
+    def find_tree_and_model():
+        nonlocal tree_view, model
+        tree_view = container.findChild(QtWidgets.QTreeView)
+        assert tree_view is not None
+        model = tree_view.model()
+        assert model is not None
+        assert model.rowCount() == 3
+
+    qtbot.waitUntil(find_tree_and_model, timeout=500)
+
+    selection_model = tree_view.selectionModel()
+    parent1 = model.item(0)
+    child12 = parent1.child(1)
+    child12_index = model.indexFromItem(child12)
+    selection_model.select(
+        child12_index,
+        QItemSelectionModel.SelectionFlag.Select
+        | QItemSelectionModel.SelectionFlag.Rows,
+    )
+
+    qtbot.waitUntil(lambda: selection_model.isSelected(child12_index), timeout=500)
+
+    state["items"] = [state["items"][2], state["items"][0], state["items"][1]]
+
+    qtbot.wait(200)
+
+    def check_after_reorder():
+        assert model.item(0).text() == "Parent 3"
+        assert model.item(1).text() == "Parent 1"
+        assert model.item(2).text() == "Parent 2"
+
+        parent1_item = model.item(1)
+        selected_child = parent1_item.child(1)
+        selected_child_index = model.indexFromItem(selected_child)
+        assert selected_child.text() == "Child 1.2"
+        assert selection_model.isSelected(selected_child_index) is True
+        assert len(selection_model.selectedRows()) == 1
+
+    qtbot.waitUntil(check_after_reorder, timeout=1000)


### PR DESCRIPTION
## What this changes
- Preserve QTreeView item UI state (selection and expansion) when keyed v-for rows are reordered in QStandardItemModel.
- Add snapshot and restore handling in:
  - collagraph/renderers/pyside/objects/itemmodel.py
  - collagraph/renderers/pyside/objects/standarditem.py
- Ensure deferred selected and expanded attributes are applied correctly when items are inserted.
- Add focused regression tests in tests/pyside/test_treeview_keyed_selection.py for:
  - bound selected and expanded surviving reorder
  - manual parent selection surviving reorder
  - manual child selection surviving parent reorder
- Add a trimmed manual demo: examples/pyside/keyed_tree_demo.cgx.

## Why
Keyed reconciliation already preserves fragment identity, but Qt model/view state can still be lost when items are detached and reinserted during reorder operations. This PR preserves that UI state so moved items keep the same selection and expansion behavior.

## Verification
- uv run pytest tests/pyside/test_treeview_keyed_selection.py -q
- Commit hooks passed on commit (lint, format, pytest).

## Notes
This PR is a reimplementation of the intent from #142 against the current codebase architecture, rather than a direct application of the old patch.