### PR TITLE
Support pygfx text elements

### DIFF
--- a/collagraph/renderers/pygfx_renderer.py
+++ b/collagraph/renderers/pygfx_renderer.py
@@ -84,6 +84,16 @@ class PygfxRenderer(Renderer):
         for attribute in attrs:
             el = getattr(el, attribute)
 
+        if isinstance(el, gfx.Text):
+            if attr == "text":
+                el.set_text(value)
+                self._trigger()
+                return
+            if attr == "markdown":
+                el.set_markdown(value)
+                self._trigger()
+                return
+
         if key not in DEFAULT_ATTR_CACHE:
             if hasattr(el, attr):
                 default_value = getattr(el, attr)

--- a/collagraph/renderers/pygfx_renderer.py
+++ b/collagraph/renderers/pygfx_renderer.py
@@ -55,9 +55,6 @@ class PygfxRenderer(Renderer):
     def create_element(self, type: str) -> gfx.WorldObject:
         """Create pygfx element for the given type"""
         type = type.lower().replace("-", "").replace("_", "")
-        if type == "textelement":
-            self._trigger()
-            return _TextElementProxy()
 
         if element_type := ELEMENT_TYPE_CACHE.get(type):
             self._trigger()
@@ -74,7 +71,8 @@ class PygfxRenderer(Renderer):
         raise ValueError(f"Can't create element of type: {type}")
 
     def create_text_element(self):
-        raise NotImplementedError
+        self._trigger()
+        return _TextElementProxy()
 
     def insert(
         self,
@@ -108,13 +106,9 @@ class PygfxRenderer(Renderer):
         self._trigger()
 
     def set_element_text(self, el, value: str):
-        if isinstance(el, _TextElementProxy):
-            el._cg_content = value
-            if parent := el._cg_parent_text:
-                self._sync_text_from_proxy_children(parent)
-            return
-
-        raise NotImplementedError
+        el._cg_content = value
+        if parent := el._cg_parent_text:
+            self._sync_text_from_proxy_children(parent)
 
     def _sync_text_from_proxy_children(self, parent: gfx.Text):
         content = "".join(
@@ -133,10 +127,6 @@ class PygfxRenderer(Renderer):
         *attrs, attr = attr.split(".")
         for attribute in attrs:
             el = getattr(el, attribute)
-
-        if isinstance(el, _TextElementProxy) and attr == "content":
-            self.set_element_text(el, value)
-            return
 
         if isinstance(el, gfx.Text):
             if attr == "text":

--- a/collagraph/renderers/pygfx_renderer.py
+++ b/collagraph/renderers/pygfx_renderer.py
@@ -1,5 +1,6 @@
 import warnings
 from typing import Any, Callable
+from weakref import ref
 
 import pygfx as gfx
 
@@ -7,6 +8,22 @@ from . import Renderer
 
 ELEMENT_TYPE_CACHE = {}
 DEFAULT_ATTR_CACHE = {}
+
+
+class _TextElementProxy(gfx.WorldObject):
+    def __init__(self):
+        super().__init__()
+        self._cg_content = ""
+        self._cg_parent_text_ref = None
+
+    @property
+    def _cg_parent_text(self) -> gfx.Text | None:
+        if self._cg_parent_text_ref is None:
+            return None
+        return self._cg_parent_text_ref()
+
+    def _cg_set_parent_text(self, parent: gfx.Text | None):
+        self._cg_parent_text_ref = ref(parent) if parent else None
 
 
 class PygfxRenderer(Renderer):
@@ -37,7 +54,11 @@ class PygfxRenderer(Renderer):
 
     def create_element(self, type: str) -> gfx.WorldObject:
         """Create pygfx element for the given type"""
-        type = type.lower().replace("-", "")
+        type = type.lower().replace("-", "").replace("_", "")
+        if type == "textelement":
+            self._trigger()
+            return _TextElementProxy()
+
         if element_type := ELEMENT_TYPE_CACHE.get(type):
             self._trigger()
             return element_type()
@@ -61,19 +82,48 @@ class PygfxRenderer(Renderer):
         parent: gfx.WorldObject,
         anchor: gfx.WorldObject | None = None,
     ):
+        is_text_proxy = isinstance(el, _TextElementProxy)
         try:
             parent.add(el, before=anchor)
         except ValueError:
             warnings.warn(f"Could not find anchor in {parent}")
             parent.add(el)
+
+        if is_text_proxy and isinstance(parent, gfx.Text):
+            el._cg_set_parent_text(parent)
+            self._sync_text_from_proxy_children(parent)
+            return
+
         self._trigger()
 
     def remove(self, el: gfx.WorldObject, parent: gfx.WorldObject):
         parent.remove(el)
+
+        if isinstance(el, _TextElementProxy):
+            if isinstance(parent, gfx.Text):
+                self._sync_text_from_proxy_children(parent)
+            el._cg_set_parent_text(None)
+            return
+
         self._trigger()
 
     def set_element_text(self, el, value: str):
+        if isinstance(el, _TextElementProxy):
+            el._cg_content = value
+            if parent := el._cg_parent_text:
+                self._sync_text_from_proxy_children(parent)
+            return
+
         raise NotImplementedError
+
+    def _sync_text_from_proxy_children(self, parent: gfx.Text):
+        content = "".join(
+            child._cg_content
+            for child in parent.children
+            if isinstance(child, _TextElementProxy)
+        )
+        parent.set_text(content)
+        self._trigger()
 
     def set_attribute(self, el: gfx.WorldObject, attr: str, value: Any):
         key = f"{type(el).__name__}.{attr}"
@@ -83,6 +133,10 @@ class PygfxRenderer(Renderer):
         *attrs, attr = attr.split(".")
         for attribute in attrs:
             el = getattr(el, attribute)
+
+        if isinstance(el, _TextElementProxy) and attr == "content":
+            self.set_element_text(el, value)
+            return
 
         if isinstance(el, gfx.Text):
             if attr == "text":

--- a/examples/pygfx/README.md
+++ b/examples/pygfx/README.md
@@ -16,6 +16,14 @@ uv run collagraph --renderer pygfx --state '{"count": 100}' examples/pygfx/point
 Shows a point cloud. Adjust the count to see how far you can push it.
 
 
+## Landmarks example
+
+```shell
+uv run collagraph --renderer pygfx --state '{"count": 25}' examples/pygfx/landmarks.cgx
+```
+Shows random 3D landmarks with labels rendered as child text nodes of `<text>` elements.
+
+
 ## Component example
 
 ```shell

--- a/examples/pygfx/README.md
+++ b/examples/pygfx/README.md
@@ -22,6 +22,7 @@ Shows a point cloud. Adjust the count to see how far you can push it.
 uv run collagraph --renderer pygfx --state '{"count": 25}' examples/pygfx/landmarks.cgx
 ```
 Shows random 3D landmarks with labels rendered as child text nodes of `<text>` elements.
+Click a landmark sphere to increment and rename its label while highlighting both sphere and text color.
 
 
 ## Component example

--- a/examples/pygfx/landmarks.cgx
+++ b/examples/pygfx/landmarks.cgx
@@ -1,0 +1,72 @@
+<!--
+Run this example as follows:
+    uv run collagraph --renderer pygfx --state '{"count": 25}' examples/pygfx/landmarks.cgx
+-->
+<ambient-light />
+<point-light :local.position="(12, 18, 10)" />
+<group>
+  <group v-for="idx, landmark in enumerate(landmarks)">
+    <mesh
+      :geometry="sphere_geometry"
+      :material="sphere_material"
+      :local.position="landmark['position']"
+    />
+    <text
+      :local.position="label_position(landmark['position'])"
+      :font_size="14"
+      screen_space
+      anchor="bottom-center"
+    >
+      {{landmark['name']}}
+      #{{idx}}
+    </text>
+  </group>
+</group>
+
+<script>
+import random
+
+import collagraph as cg
+import pygfx as gfx
+
+sphere_geometry = gfx.sphere_geometry(radius=0.35)
+sphere_material = gfx.MeshPhongMaterial(color=[0.2, 0.8, 1.0], pick_write=True)
+
+LANDMARK_NAMES = [
+    "Harbor",
+    "Bridge",
+    "Museum",
+    "Library",
+    "Station",
+    "Observatory",
+    "Garden",
+    "Square",
+    "Market",
+    "Beacon",
+]
+
+
+def rand_position():
+    return (
+        round(random.uniform(-12.0, 12.0), 2),
+        round(random.uniform(-8.0, 8.0), 2),
+        round(random.uniform(-12.0, 12.0), 2),
+    )
+
+
+class Landmarks(cg.Component):
+    def init(self):
+        random.seed(42)
+        count = int(self.props.get("count", 20))
+        self.state["landmarks"] = [
+            {
+                "name": LANDMARK_NAMES[idx % len(LANDMARK_NAMES)],
+                "position": rand_position(),
+            }
+            for idx in range(count)
+        ]
+
+    def label_position(self, position):
+        x, y, z = position
+        return (x, y + 0.75, z)
+</script>

--- a/examples/pygfx/landmarks.cgx
+++ b/examples/pygfx/landmarks.cgx
@@ -4,23 +4,22 @@ Run this example as follows:
 -->
 <ambient-light />
 <point-light :local.position="(12, 18, 10)" />
-<group>
-  <group v-for="idx, landmark in enumerate(landmarks)">
+<group v-for="idx, landmark in enumerate(landmarks)">
+  <group :local.position="landmark['position']">
     <mesh
       :geometry="sphere_geometry"
       :material="selected_sphere_material if idx == selected else sphere_material"
-      :local.position="landmark['position']"
       @click="lambda ev: click_landmark(idx)"
     />
     <text
-      :local.position="label_position(landmark['position'])"
+      anchor="bottom-center"
       :font_size="14"
+      :local.position="(0, 0.75, 0)"
       :material="selected_label_material if idx == selected else label_material"
       screen_space
-      anchor="bottom-center"
     >
       {{landmark['name']}}
-      #{{idx}}
+        #{{idx}}
     </text>
   </group>
 </group>
@@ -30,6 +29,7 @@ import random
 
 import collagraph as cg
 import pygfx as gfx
+
 
 sphere_geometry = gfx.sphere_geometry(radius=0.35)
 sphere_material = gfx.MeshPhongMaterial(color=[0.2, 0.8, 1.0], pick_write=True)
@@ -75,13 +75,10 @@ class Landmarks(cg.Component):
             for idx in range(count)
         ]
 
-    def label_position(self, position):
-        x, y, z = position
-        return (x, y + 0.75, z)
-
     def click_landmark(self, idx):
         landmark = self.state["landmarks"][idx]
         landmark["clicks"] += 1
         landmark["name"] = f"{landmark['base_name']} ({landmark['clicks']})"
         self.state["selected"] = idx
 </script>
+

--- a/examples/pygfx/landmarks.cgx
+++ b/examples/pygfx/landmarks.cgx
@@ -8,12 +8,14 @@ Run this example as follows:
   <group v-for="idx, landmark in enumerate(landmarks)">
     <mesh
       :geometry="sphere_geometry"
-      :material="sphere_material"
+      :material="selected_sphere_material if idx == selected else sphere_material"
       :local.position="landmark['position']"
+      @click="lambda ev: click_landmark(idx)"
     />
     <text
       :local.position="label_position(landmark['position'])"
       :font_size="14"
+      :material="selected_label_material if idx == selected else label_material"
       screen_space
       anchor="bottom-center"
     >
@@ -31,6 +33,10 @@ import pygfx as gfx
 
 sphere_geometry = gfx.sphere_geometry(radius=0.35)
 sphere_material = gfx.MeshPhongMaterial(color=[0.2, 0.8, 1.0], pick_write=True)
+selected_sphere_material = gfx.MeshPhongMaterial(color=[1.0, 0.4, 0.2], pick_write=True)
+
+label_material = gfx.TextMaterial(color="#D6F4FF")
+selected_label_material = gfx.TextMaterial(color="#FFE066")
 
 LANDMARK_NAMES = [
     "Harbor",
@@ -58,10 +64,13 @@ class Landmarks(cg.Component):
     def init(self):
         random.seed(42)
         count = int(self.props.get("count", 20))
+        self.state["selected"] = -1
         self.state["landmarks"] = [
             {
+                "base_name": LANDMARK_NAMES[idx % len(LANDMARK_NAMES)],
                 "name": LANDMARK_NAMES[idx % len(LANDMARK_NAMES)],
                 "position": rand_position(),
+                "clicks": 0,
             }
             for idx in range(count)
         ]
@@ -69,4 +78,10 @@ class Landmarks(cg.Component):
     def label_position(self, position):
         x, y, z = position
         return (x, y + 0.75, z)
+
+    def click_landmark(self, idx):
+        landmark = self.state["landmarks"][idx]
+        landmark["clicks"] += 1
+        landmark["name"] = f"{landmark['base_name']} ({landmark['clicks']})"
+        self.state["selected"] = idx
 </script>

--- a/tests/test_pygfx_renderer.py
+++ b/tests/test_pygfx_renderer.py
@@ -32,15 +32,19 @@ def test_pygfx_create_element():
         renderer.create_element("Foo")
 
 
-def test_pygfx_text_element_not_supported():
+def test_pygfx_text_element_support():
     renderer = PygfxRenderer()
-    obj = renderer.create_element("scene")
+    parent = gfx.Text()
+    proxy = renderer.create_text_element()
 
-    with pytest.raises(NotImplementedError):
-        renderer.create_text_element()
+    renderer.set_element_text(proxy, "Hello")
+    renderer.insert(proxy, parent)
+    assert len(parent.children) == 1
+    assert parent.children[0] is proxy
+    assert len(parent._text_blocks) == 1
 
-    with pytest.raises(NotImplementedError):
-        renderer.set_element_text(obj, "Foo")
+    renderer.set_element_text(proxy, "Hello world")
+    assert len(parent._text_blocks) == 1
 
 
 def test_pygfx_insert_remove():
@@ -169,7 +173,7 @@ def test_pygfx_text_attributes_use_text_api(monkeypatch):
 def test_pygfx_create_text_element_returns_proxy():
     renderer = PygfxRenderer()
 
-    proxy = renderer.create_element("TEXT_ELEMENT")
+    proxy = renderer.create_text_element()
 
     assert isinstance(proxy, gfx.WorldObject)
     assert hasattr(proxy, "_cg_content")
@@ -178,7 +182,7 @@ def test_pygfx_create_text_element_returns_proxy():
 def test_pygfx_text_proxy_content_update_resyncs_parent_text(monkeypatch):
     renderer = PygfxRenderer()
     parent = gfx.Text()
-    proxy = renderer.create_element("TEXT_ELEMENT")
+    proxy = renderer.create_text_element()
 
     calls = []
 
@@ -187,13 +191,13 @@ def test_pygfx_text_proxy_content_update_resyncs_parent_text(monkeypatch):
 
     monkeypatch.setattr(parent, "set_text", set_text)
 
-    renderer.set_attribute(proxy, "content", "Hello")
+    renderer.set_element_text(proxy, "Hello")
     assert calls == []
 
     renderer.insert(proxy, parent)
     assert calls == ["Hello"]
 
-    renderer.set_attribute(proxy, "content", "Updated")
+    renderer.set_element_text(proxy, "Updated")
     assert calls == ["Hello", "Updated"]
 
 
@@ -208,13 +212,13 @@ def test_pygfx_text_multiple_proxies_concatenate_in_children_order(monkeypatch):
 
     monkeypatch.setattr(parent, "set_text", set_text)
 
-    a = renderer.create_element("TEXT_ELEMENT")
-    b = renderer.create_element("TEXT_ELEMENT")
-    c = renderer.create_element("TEXT_ELEMENT")
+    a = renderer.create_text_element()
+    b = renderer.create_text_element()
+    c = renderer.create_text_element()
 
-    renderer.set_attribute(a, "content", "A")
-    renderer.set_attribute(b, "content", "B")
-    renderer.set_attribute(c, "content", "C")
+    renderer.set_element_text(a, "A")
+    renderer.set_element_text(b, "B")
+    renderer.set_element_text(c, "C")
 
     renderer.insert(a, parent)
     renderer.insert(b, parent)
@@ -234,13 +238,13 @@ def test_pygfx_text_anchor_insert_updates_composition_order(monkeypatch):
 
     monkeypatch.setattr(parent, "set_text", set_text)
 
-    a = renderer.create_element("TEXT_ELEMENT")
-    b = renderer.create_element("TEXT_ELEMENT")
-    c = renderer.create_element("TEXT_ELEMENT")
+    a = renderer.create_text_element()
+    b = renderer.create_text_element()
+    c = renderer.create_text_element()
 
-    renderer.set_attribute(a, "content", "A")
-    renderer.set_attribute(b, "content", "B")
-    renderer.set_attribute(c, "content", "C")
+    renderer.set_element_text(a, "A")
+    renderer.set_element_text(b, "B")
+    renderer.set_element_text(c, "C")
 
     renderer.insert(a, parent)
     renderer.insert(c, parent)
@@ -260,13 +264,13 @@ def test_pygfx_text_remove_middle_proxy_recomputes_joined_text(monkeypatch):
 
     monkeypatch.setattr(parent, "set_text", set_text)
 
-    a = renderer.create_element("TEXT_ELEMENT")
-    b = renderer.create_element("TEXT_ELEMENT")
-    c = renderer.create_element("TEXT_ELEMENT")
+    a = renderer.create_text_element()
+    b = renderer.create_text_element()
+    c = renderer.create_text_element()
 
-    renderer.set_attribute(a, "content", "A")
-    renderer.set_attribute(b, "content", "B")
-    renderer.set_attribute(c, "content", "C")
+    renderer.set_element_text(a, "A")
+    renderer.set_element_text(b, "B")
+    renderer.set_element_text(c, "C")
 
     renderer.insert(a, parent)
     renderer.insert(b, parent)
@@ -279,7 +283,7 @@ def test_pygfx_text_remove_middle_proxy_recomputes_joined_text(monkeypatch):
 def test_pygfx_text_proxy_update_after_remove_does_not_resync(monkeypatch):
     renderer = PygfxRenderer()
     parent = gfx.Text()
-    proxy = renderer.create_element("TEXT_ELEMENT")
+    proxy = renderer.create_text_element()
 
     calls = []
 
@@ -288,12 +292,12 @@ def test_pygfx_text_proxy_update_after_remove_does_not_resync(monkeypatch):
 
     monkeypatch.setattr(parent, "set_text", set_text)
 
-    renderer.set_attribute(proxy, "content", "A")
+    renderer.set_element_text(proxy, "A")
     renderer.insert(proxy, parent)
     renderer.remove(proxy, parent)
 
     call_count = len(calls)
-    renderer.set_attribute(proxy, "content", "B")
+    renderer.set_element_text(proxy, "B")
 
     assert len(calls) == call_count
 
@@ -309,12 +313,12 @@ def test_pygfx_text_sync_ignores_non_proxy_children(monkeypatch):
 
     monkeypatch.setattr(parent, "set_text", set_text)
 
-    proxy_a = renderer.create_element("TEXT_ELEMENT")
-    proxy_b = renderer.create_element("TEXT_ELEMENT")
+    proxy_a = renderer.create_text_element()
+    proxy_b = renderer.create_text_element()
     non_proxy = gfx.WorldObject()
 
-    renderer.set_attribute(proxy_a, "content", "A")
-    renderer.set_attribute(proxy_b, "content", "B")
+    renderer.set_element_text(proxy_a, "A")
+    renderer.set_element_text(proxy_b, "B")
 
     renderer.insert(proxy_a, parent)
     renderer.insert(non_proxy, parent)

--- a/tests/test_pygfx_renderer.py
+++ b/tests/test_pygfx_renderer.py
@@ -141,6 +141,29 @@ def test_pygfx_attributes():
     assert material.clipping_planes == original_clipping_planes
 
 
+def test_pygfx_text_attributes_use_text_api(monkeypatch):
+    renderer = PygfxRenderer()
+    text = gfx.Text()
+
+    calls = []
+
+    def set_text(value):
+        calls.append(("text", value))
+
+    def set_markdown(value):
+        calls.append(("markdown", value))
+
+    monkeypatch.setattr(text, "set_text", set_text)
+    monkeypatch.setattr(text, "set_markdown", set_markdown)
+
+    renderer.set_attribute(text, "text", "Hello")
+    renderer.set_attribute(text, "markdown", "**World**")
+
+    assert calls == [("text", "Hello"), ("markdown", "**World**")]
+    assert "text" not in text.__dict__
+    assert "markdown" not in text.__dict__
+
+
 def test_event_handlers():
     renderer = PygfxRenderer()
 

--- a/tests/test_pygfx_renderer.py
+++ b/tests/test_pygfx_renderer.py
@@ -2,12 +2,14 @@ import math
 from collections import namedtuple
 
 import pytest
+from observ import reactive
 
 try:
     import pygfx as gfx
 except ImportError:
     pytest.skip(reason="pygfx not installed", allow_module_level=True)
 
+from collagraph import Collagraph, EventLoopType
 from collagraph.renderers import PygfxRenderer
 
 
@@ -162,6 +164,199 @@ def test_pygfx_text_attributes_use_text_api(monkeypatch):
     assert calls == [("text", "Hello"), ("markdown", "**World**")]
     assert "text" not in text.__dict__
     assert "markdown" not in text.__dict__
+
+
+def test_pygfx_create_text_element_returns_proxy():
+    renderer = PygfxRenderer()
+
+    proxy = renderer.create_element("TEXT_ELEMENT")
+
+    assert isinstance(proxy, gfx.WorldObject)
+    assert hasattr(proxy, "_cg_content")
+
+
+def test_pygfx_text_proxy_content_update_resyncs_parent_text(monkeypatch):
+    renderer = PygfxRenderer()
+    parent = gfx.Text()
+    proxy = renderer.create_element("TEXT_ELEMENT")
+
+    calls = []
+
+    def set_text(value):
+        calls.append(value)
+
+    monkeypatch.setattr(parent, "set_text", set_text)
+
+    renderer.set_attribute(proxy, "content", "Hello")
+    assert calls == []
+
+    renderer.insert(proxy, parent)
+    assert calls == ["Hello"]
+
+    renderer.set_attribute(proxy, "content", "Updated")
+    assert calls == ["Hello", "Updated"]
+
+
+def test_pygfx_text_multiple_proxies_concatenate_in_children_order(monkeypatch):
+    renderer = PygfxRenderer()
+    parent = gfx.Text()
+
+    calls = []
+
+    def set_text(value):
+        calls.append(value)
+
+    monkeypatch.setattr(parent, "set_text", set_text)
+
+    a = renderer.create_element("TEXT_ELEMENT")
+    b = renderer.create_element("TEXT_ELEMENT")
+    c = renderer.create_element("TEXT_ELEMENT")
+
+    renderer.set_attribute(a, "content", "A")
+    renderer.set_attribute(b, "content", "B")
+    renderer.set_attribute(c, "content", "C")
+
+    renderer.insert(a, parent)
+    renderer.insert(b, parent)
+    renderer.insert(c, parent)
+
+    assert calls[-1] == "ABC"
+
+
+def test_pygfx_text_anchor_insert_updates_composition_order(monkeypatch):
+    renderer = PygfxRenderer()
+    parent = gfx.Text()
+
+    calls = []
+
+    def set_text(value):
+        calls.append(value)
+
+    monkeypatch.setattr(parent, "set_text", set_text)
+
+    a = renderer.create_element("TEXT_ELEMENT")
+    b = renderer.create_element("TEXT_ELEMENT")
+    c = renderer.create_element("TEXT_ELEMENT")
+
+    renderer.set_attribute(a, "content", "A")
+    renderer.set_attribute(b, "content", "B")
+    renderer.set_attribute(c, "content", "C")
+
+    renderer.insert(a, parent)
+    renderer.insert(c, parent)
+    renderer.insert(b, parent, anchor=c)
+
+    assert calls[-1] == "ABC"
+
+
+def test_pygfx_text_remove_middle_proxy_recomputes_joined_text(monkeypatch):
+    renderer = PygfxRenderer()
+    parent = gfx.Text()
+
+    calls = []
+
+    def set_text(value):
+        calls.append(value)
+
+    monkeypatch.setattr(parent, "set_text", set_text)
+
+    a = renderer.create_element("TEXT_ELEMENT")
+    b = renderer.create_element("TEXT_ELEMENT")
+    c = renderer.create_element("TEXT_ELEMENT")
+
+    renderer.set_attribute(a, "content", "A")
+    renderer.set_attribute(b, "content", "B")
+    renderer.set_attribute(c, "content", "C")
+
+    renderer.insert(a, parent)
+    renderer.insert(b, parent)
+    renderer.insert(c, parent)
+    renderer.remove(b, parent)
+
+    assert calls[-1] == "AC"
+
+
+def test_pygfx_text_proxy_update_after_remove_does_not_resync(monkeypatch):
+    renderer = PygfxRenderer()
+    parent = gfx.Text()
+    proxy = renderer.create_element("TEXT_ELEMENT")
+
+    calls = []
+
+    def set_text(value):
+        calls.append(value)
+
+    monkeypatch.setattr(parent, "set_text", set_text)
+
+    renderer.set_attribute(proxy, "content", "A")
+    renderer.insert(proxy, parent)
+    renderer.remove(proxy, parent)
+
+    call_count = len(calls)
+    renderer.set_attribute(proxy, "content", "B")
+
+    assert len(calls) == call_count
+
+
+def test_pygfx_text_sync_ignores_non_proxy_children(monkeypatch):
+    renderer = PygfxRenderer()
+    parent = gfx.Text()
+
+    calls = []
+
+    def set_text(value):
+        calls.append(value)
+
+    monkeypatch.setattr(parent, "set_text", set_text)
+
+    proxy_a = renderer.create_element("TEXT_ELEMENT")
+    proxy_b = renderer.create_element("TEXT_ELEMENT")
+    non_proxy = gfx.WorldObject()
+
+    renderer.set_attribute(proxy_a, "content", "A")
+    renderer.set_attribute(proxy_b, "content", "B")
+
+    renderer.insert(proxy_a, parent)
+    renderer.insert(non_proxy, parent)
+    renderer.insert(proxy_b, parent)
+
+    assert calls[-1] == "AB"
+
+
+def test_pygfx_template_text_children_update(parse_source, monkeypatch):
+    App, _ = parse_source(
+        """
+        <scene>
+          <text>Hello {{name}}!</text>
+        </scene>
+
+        <script>
+        import collagraph as cg
+
+        class App(cg.Component):
+            pass
+        </script>
+        """
+    )
+
+    calls = []
+    original_set_text = gfx.Text.set_text
+
+    def set_text(self, value):
+        calls.append(value)
+        original_set_text(self, value)
+
+    monkeypatch.setattr(gfx.Text, "set_text", set_text)
+
+    state = reactive({"name": "World"})
+    container = gfx.Scene()
+    gui = Collagraph(PygfxRenderer(), event_loop_type=EventLoopType.SYNC)
+
+    gui.render(App, container, state)
+    assert calls[-1] == "Hello World!"
+
+    state["name"] = "Collagraph"
+    assert calls[-1] == "Hello Collagraph!"
 
 
 def test_event_handlers():


### PR DESCRIPTION
## Summary
- use the renderer text-element API in `PygfxRenderer` by creating text proxies via `create_text_element()`
- update pygfx renderer tests to exercise `create_text_element()` and `set_element_text()` directly for proxy composition
- include interactive pygfx landmark examples demonstrating child text-node rendering and text/material updates

Sneak peak of added example:
<img width="567" height="462" alt="image" src="https://github.com/user-attachments/assets/e42cced7-ce74-4799-97cf-944f2f8ef36f" />
