### PR TITLE
Add benchmark suite and fix core rendering hot-path inefficiencies

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,56 @@
+name: Benchmarks
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  benchmark:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync
+
+      # On PRs: run benchmarks twice (PR code vs master code) and compare
+      - name: Run benchmarks
+        run: |
+          # Checkout master version of collagraph directory
+          git fetch origin master
+          git checkout origin/master -- collagraph/
+
+          # Run benchmarks with master code as baseline
+          uv run --no-sync pytest bench \
+              --benchmark-only \
+              --benchmark-save=master \
+              --benchmark-sort=mean || true
+
+          # Restore PR code
+          git checkout HEAD -- collagraph/
+
+          # Run benchmarks on PR code and compare
+          uv run --no-sync pytest bench \
+              --benchmark-only \
+              --benchmark-compare \
+              --benchmark-compare-fail=mean:5% \
+              --benchmark-save=branch \
+              --benchmark-sort=mean
+
+      - name: Upload benchmarks
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Benchmarks
+          path: .benchmarks/
+          include-hidden-files: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 *.spec
 uv.lock
 .venv
+.benchmarks

--- a/bench/conftest.py
+++ b/bench/conftest.py
@@ -1,0 +1,10 @@
+"""Reuse existing test fixtures/helpers for collagraph benchmarks."""
+
+from tests.conftest import (  # noqa: F401
+    CustomElement,
+    CustomElementRenderer,
+    TrackingRenderer,
+    cleanup,
+    parse_source,
+    process_events,
+)

--- a/bench/test_component_mount.py
+++ b/bench/test_component_mount.py
@@ -1,0 +1,66 @@
+"""
+Benchmarks for mounting a chain of nested components.
+
+Each level is its own ComponentFragment, so this stresses per-component
+mount overhead: the weak()-wrapped ref/bind watchers set up in
+ComponentFragment.create(), and the root-element lookup at the end of
+ComponentFragment.mount() (self.first()).
+"""
+
+import pytest
+
+from collagraph import Collagraph, EventLoopType
+from collagraph.renderers import DictRenderer
+
+DEPTHS = [10, 50, 200]
+
+
+def _build_nested_component(parse_source, depth):
+    Leaf, _ = parse_source(
+        """
+        <leaf />
+
+        <script>
+        import collagraph as cg
+
+        class Leaf(cg.Component):
+            pass
+        </script>
+        """
+    )
+
+    prev = Leaf
+    prev_name = "Leaf"
+    for i in range(depth):
+        name = f"Wrapper{i}"
+        prev, _ = parse_source(
+            f"""
+            <div>
+              <{prev_name} />
+            </div>
+
+            <script>
+            import collagraph as cg
+
+            class {name}(cg.Component):
+                pass
+            </script>
+            """,
+            namespace={prev_name: prev},
+        )
+        prev_name = name
+
+    return prev
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="mount_nested_components")
+@pytest.mark.parametrize("depth", DEPTHS, ids=[str(d) for d in DEPTHS])
+def test_mount_nested_components(benchmark, parse_source, depth):
+    App = _build_nested_component(parse_source, depth)
+
+    def mount():
+        gui = Collagraph(renderer=DictRenderer(), event_loop_type=EventLoopType.SYNC)
+        gui.render(App, {"type": "root"})
+
+    benchmark(mount)

--- a/bench/test_creation.py
+++ b/bench/test_creation.py
@@ -1,0 +1,71 @@
+"""
+Benchmarks for the cost of mounting a fragment tree from scratch.
+
+Mounting stresses Fragment.create()/mount(), and for elements with a
+dynamic bind, also the watcher-setup path (`_watch_bind`) which relies
+on the `weak()` decorator for every callback registration.
+"""
+
+import pytest
+from observ import reactive
+
+from collagraph import Collagraph, EventLoopType
+from collagraph.renderers import DictRenderer
+
+SIZES = [10, 100, 1_000]
+SIZE_IDS = ["10", "100", "1k"]
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="mount_plain_elements")
+@pytest.mark.parametrize("n", SIZES, ids=SIZE_IDS)
+def test_mount_plain_elements(benchmark, parse_source, n):
+    children = "\n".join("        <item />" for _ in range(n))
+    App, _ = parse_source(
+        f"""
+        <root>
+{children}
+        </root>
+
+        <script>
+        import collagraph as cg
+
+        class App(cg.Component):
+            pass
+        </script>
+        """
+    )
+
+    def mount():
+        gui = Collagraph(renderer=DictRenderer(), event_loop_type=EventLoopType.SYNC)
+        gui.render(App, {"type": "root"})
+
+    benchmark(mount)
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="mount_bound_elements")
+@pytest.mark.parametrize("n", SIZES, ids=SIZE_IDS)
+def test_mount_bound_elements(benchmark, parse_source, n):
+    children = "\n".join(f'        <item :value="v{i}" />' for i in range(n))
+    App, _ = parse_source(
+        f"""
+        <root>
+{children}
+        </root>
+
+        <script>
+        import collagraph as cg
+
+        class App(cg.Component):
+            pass
+        </script>
+        """
+    )
+    state = reactive({f"v{i}": i for i in range(n)})
+
+    def mount():
+        gui = Collagraph(renderer=DictRenderer(), event_loop_type=EventLoopType.SYNC)
+        gui.render(App, {"type": "root"}, state=state)
+
+    benchmark(mount)

--- a/bench/test_keyed_list.py
+++ b/bench/test_keyed_list.py
@@ -1,0 +1,74 @@
+"""
+Benchmarks for keyed v-for reconciliation.
+
+Stresses ListFragment's keyed reconciliation path: the LIS computation
+and Fragment.anchor() lookups used to reposition/insert fragments.
+
+Each round replaces the whole `items` list in one reactive assignment
+(the idiomatic way to reorder/replace a collection), rather than doing
+many individual in-place mutations, which would each trigger their own
+full reconciliation pass and dominate the measurement with unrelated
+per-mutation dependency-tracking cost.
+"""
+
+import random
+
+import pytest
+from observ import reactive
+
+from collagraph import Collagraph, EventLoopType
+from collagraph.renderers import DictRenderer
+
+SIZES = [10, 100, 1_000]
+SIZE_IDS = ["10", "100", "1k"]
+PATTERNS = ["append", "prepend", "reverse", "shuffle"]
+
+
+def _new_items(items, pattern):
+    if pattern == "append":
+        return [*items, {"id": len(items), "text": "x"}]
+    if pattern == "prepend":
+        return [{"id": len(items), "text": "x"}, *items]
+    if pattern == "reverse":
+        return list(reversed(items))
+    if pattern == "shuffle":
+        shuffled = list(items)
+        random.Random(0).shuffle(shuffled)
+        return shuffled
+    raise ValueError(pattern)
+
+
+def _apply(gui, state, items):
+    # `gui` is unused but must be kept as a live argument: it holds the
+    # only strong reference to the mounted fragment tree, so passing it
+    # through keeps that tree alive for the duration of the timed call.
+    state["items"] = items
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="keyed_list_reconcile")
+@pytest.mark.parametrize("n", SIZES, ids=SIZE_IDS)
+@pytest.mark.parametrize("pattern", PATTERNS)
+def test_keyed_list_reconcile(benchmark, parse_source, pattern, n):
+    App, _ = parse_source(
+        """
+        <node v-for="item in items" :key="item['id']" :text="item['text']" />
+
+        <script>
+        import collagraph as cg
+
+        class App(cg.Component):
+            pass
+        </script>
+        """
+    )
+
+    def setup():
+        initial = [{"id": i, "text": str(i)} for i in range(n)]
+        state = reactive({"items": list(initial)})
+        gui = Collagraph(renderer=DictRenderer(), event_loop_type=EventLoopType.SYNC)
+        gui.render(App, {"type": "root"}, state=state)
+        new_items = _new_items(initial, pattern)
+        return (gui, state, new_items), {}
+
+    benchmark.pedantic(_apply, setup=setup, warmup_rounds=1, rounds=30)

--- a/bench/test_unkeyed_list.py
+++ b/bench/test_unkeyed_list.py
@@ -1,0 +1,70 @@
+"""
+Benchmarks for unkeyed v-for reconciliation (index-based), for comparison
+against the keyed reconciliation path in test_keyed_list.py.
+
+Each round replaces the whole `items` list in one reactive assignment,
+see test_keyed_list.py for why (avoids per-mutation reconciliation cost
+from dominating the measurement).
+"""
+
+import random
+
+import pytest
+from observ import reactive
+
+from collagraph import Collagraph, EventLoopType
+from collagraph.renderers import DictRenderer
+
+SIZES = [10, 100, 1_000]
+SIZE_IDS = ["10", "100", "1k"]
+PATTERNS = ["append", "prepend", "reverse", "shuffle"]
+
+
+def _new_items(items, pattern):
+    if pattern == "append":
+        return [*items, {"text": "x"}]
+    if pattern == "prepend":
+        return [{"text": "x"}, *items]
+    if pattern == "reverse":
+        return list(reversed(items))
+    if pattern == "shuffle":
+        shuffled = list(items)
+        random.Random(0).shuffle(shuffled)
+        return shuffled
+    raise ValueError(pattern)
+
+
+def _apply(gui, state, items):
+    # `gui` is unused but must be kept as a live argument: it holds the
+    # only strong reference to the mounted fragment tree, so passing it
+    # through keeps that tree alive for the duration of the timed call.
+    state["items"] = items
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="unkeyed_list_reconcile")
+@pytest.mark.parametrize("n", SIZES, ids=SIZE_IDS)
+@pytest.mark.parametrize("pattern", PATTERNS)
+def test_unkeyed_list_reconcile(benchmark, parse_source, pattern, n):
+    App, _ = parse_source(
+        """
+        <node v-for="item in items" :text="item['text']" />
+
+        <script>
+        import collagraph as cg
+
+        class App(cg.Component):
+            pass
+        </script>
+        """
+    )
+
+    def setup():
+        initial = [{"text": str(i)} for i in range(n)]
+        state = reactive({"items": list(initial)})
+        gui = Collagraph(renderer=DictRenderer(), event_loop_type=EventLoopType.SYNC)
+        gui.render(App, {"type": "root"}, state=state)
+        new_items = _new_items(initial, pattern)
+        return (gui, state, new_items), {}
+
+    benchmark.pedantic(_apply, setup=setup, warmup_rounds=1, rounds=30)

--- a/bench/test_update_depth.py
+++ b/bench/test_update_depth.py
@@ -1,0 +1,48 @@
+"""
+Benchmarks for updating a single reactive prop on a leaf element nested at
+varying depth.
+
+Every attribute update on a mounted fragment calls
+Fragment._component_parent() to find the owning component's `updated()`
+hook, which walks the parent chain. This stresses that walk relative to
+tree depth.
+"""
+
+import pytest
+from observ import reactive
+
+from collagraph import Collagraph, EventLoopType
+from collagraph.renderers import DictRenderer
+
+DEPTHS = [10, 50, 200]
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="update_at_depth")
+@pytest.mark.parametrize("depth", DEPTHS, ids=[str(d) for d in DEPTHS])
+def test_update_attribute_at_depth(benchmark, parse_source, depth):
+    open_tags = "<div>" * depth
+    close_tags = "</div>" * depth
+    App, _ = parse_source(
+        f"""
+        {open_tags}<leaf :value="value" />{close_tags}
+
+        <script>
+        import collagraph as cg
+
+        class App(cg.Component):
+            pass
+        </script>
+        """
+    )
+    state = reactive({"value": 0})
+    gui = Collagraph(renderer=DictRenderer(), event_loop_type=EventLoopType.SYNC)
+    gui.render(App, {"type": "root"}, state=state)
+
+    counter = {"i": 0}
+
+    def update():
+        counter["i"] += 1
+        state["value"] = counter["i"]
+
+    benchmark(update)

--- a/collagraph/fragment.py
+++ b/collagraph/fragment.py
@@ -11,6 +11,9 @@ from .component import Component
 from .renderers import Renderer
 from .weak import weak
 
+# Sentinel for an unpopulated Fragment._component_parent_cache
+_UNSET = object()
+
 
 class Fragment:
     """
@@ -45,6 +48,10 @@ class Fragment:
 
         # Weak ref to parent fragment
         self._parent: ref[Fragment] | None = ref(parent) if parent else None
+        # Cache for _component_parent(), invalidated whenever this fragment
+        # is reparented to a different owner (see the `parent` setter and
+        # DynamicFragment._create_fragment_for_tag)
+        self._component_parent_cache: Component | None = _UNSET
         # Static attributes for the DOM element
         self._attributes: dict[str, str] = {}
         # Events for the DOM element
@@ -88,22 +95,31 @@ class Fragment:
         Returns the component of the first parent ComponentFragment that
         has a component property. Or None, if not there.
 
+        Cached, since parenthood is stable once a fragment is mounted. The
+        cache is invalidated whenever a fragment is reparented to a
+        different owner (see the `parent` setter and
+        DynamicFragment._create_fragment_for_tag, the only place a live,
+        already-mounted fragment's parent is reassigned directly).
         """
-        # TODO: would be nice if we could cache the _component_parent in a clever way
+        if self._component_parent_cache is not _UNSET:
+            return self._component_parent_cache
+
         parent = self.parent
         while parent and (
             not isinstance(parent, ComponentFragment) or not parent.component
         ):
             parent = parent.parent
 
-        if parent:
-            return parent.component
+        result = parent.component if parent else None
+        self._component_parent_cache = result
+        return result
 
     @parent.setter
     def parent(self, parent: Fragment | None):
         # TODO: should this also check that this item is
         # now in the list of the parent's children?
         self._parent = ref(parent) if parent else None
+        self._component_parent_cache = _UNSET
 
     def register_child(self, child: Fragment) -> None:
         self.children.append(child)
@@ -129,8 +145,12 @@ class Fragment:
         assert parent is not None
 
         # Check if this fragment is in parent's children
-        if self in parent.children:
+        try:
             idx = parent.children.index(self)
+        except ValueError:
+            idx = None
+
+        if idx is not None:
             length = len(parent.children) - 1
             while 0 <= idx < length:
                 idx += 1
@@ -138,13 +158,18 @@ class Fragment:
                     return element
         # Fragment might be slot content - check parent's slot_contents if it's
         # a ComponentFragment
-        elif isinstance(parent, ComponentFragment) and self in parent.slot_contents:
-            idx = parent.slot_contents.index(self)
-            length = len(parent.slot_contents) - 1
-            while 0 <= idx < length:
-                idx += 1
-                if element := parent.slot_contents[idx].first():
-                    return element
+        elif isinstance(parent, ComponentFragment):
+            try:
+                idx = parent.slot_contents.index(self)
+            except ValueError:
+                idx = None
+
+            if idx is not None:
+                length = len(parent.slot_contents) - 1
+                while 0 <= idx < length:
+                    idx += 1
+                    if element := parent.slot_contents[idx].first():
+                        return element
 
         # No sibling anchor found at this level. If the parent doesn't have
         # its own element (e.g., ComponentFragment, ControlFlowFragment), climb
@@ -448,6 +473,7 @@ class Fragment:
             self.tag = None
             self._ref_name = None
             self._ref_is_dynamic = False
+            self._component_parent_cache = _UNSET
         else:
             self.element = None
             # Disable the fn and callback of the watcher to disable
@@ -809,20 +835,7 @@ class ComponentFragment(Fragment):
                 child.mount(target, anchor)
 
         if self.component:
-            from collections import deque
-
-            # Use fifo data structure (double-ended queue)
-            lookup = deque(self.children)
-            try:
-                while True:
-                    child = lookup.popleft()
-                    if element := child.element:
-                        self.component._element = element
-                        lookup.clear()
-                        break
-                    lookup.extend(child.children)
-            except IndexError:
-                pass
+            self.component._element = self.first()
 
             # Register static component ref after component is mounted
             # (dynamic refs are handled by the watcher created in create())
@@ -1051,6 +1064,13 @@ class DynamicFragment(Fragment):
         # Create the fragment
         self._active_fragment.create()
 
+        # `existing_children` (and their descendants) may have been mounted
+        # under a different owning component before this tag switch (e.g.
+        # transferred out of a previous ComponentFragment's slot_contents).
+        # Their cached _component_parent() result would now be stale, since
+        # their effective parent chain just changed.
+        _invalidate_component_parent_cache(self._active_fragment)
+
     def mount(self, target: Any, anchor: Any | None = None):
         if self._mounted:
             return
@@ -1114,6 +1134,36 @@ class DynamicFragment(Fragment):
     def _remove(self):
         if self._active_fragment:
             self._active_fragment._remove()
+
+
+def _invalidate_component_parent_cache(fragment: Fragment | None) -> None:
+    """
+    Recursively reset the cached _component_parent() result for `fragment`
+    and its descendants.
+
+    Needed after a live, already-mounted fragment is reparented to a
+    different owner without going through the `parent` property setter
+    (currently only DynamicFragment._create_fragment_for_tag does this,
+    when transferring existing children to a newly created active
+    fragment on a `<component :is=...>` tag switch).
+    """
+    if fragment is None:
+        return
+
+    fragment._component_parent_cache = _UNSET
+
+    for child in fragment.children:
+        _invalidate_component_parent_cache(child)
+
+    if isinstance(fragment, ComponentFragment):
+        # Note: fragment.fragment (the component's rendered template root)
+        # is already reachable via fragment.children, since create() always
+        # appends it there.
+        for slot_content in fragment.slot_contents:
+            _invalidate_component_parent_cache(slot_content)
+
+    if isinstance(fragment, DynamicFragment):
+        _invalidate_component_parent_cache(fragment._active_fragment)
 
 
 def move_fragment_dom(

--- a/collagraph/weak.py
+++ b/collagraph/weak.py
@@ -1,5 +1,4 @@
 from functools import wraps
-from inspect import signature
 from weakref import ref
 
 
@@ -29,11 +28,7 @@ def weak(obj):
     weak_obj = ref(obj)
 
     def wrapper(method):
-        sig = signature(method)
-        non_default_parameters = [
-            par for par in sig.parameters.values() if par.default is par.empty
-        ]
-        nr_arguments = len(non_default_parameters)
+        nr_arguments = method.__code__.co_argcount - len(method.__defaults__ or ())
 
         if nr_arguments == 0:
             raise TypeError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ dev = [
     "colorlog",
     "pre-commit",
     "pytest",
+    "pytest-benchmark",
     "pytest-cov",
+    "pytest-timeout",
     "rich",
     "ruff",
     "twine",
@@ -51,6 +53,7 @@ pyside-dev = [
 # pygfx = { git = "https://github.com/pygfx/pygfx" }
 
 [tool.ruff.lint.per-file-ignores]
+"bench/*" = ["F821", "N806"]  # undefined-name, non-lowercase-variable-in-function
 "collagraph/__init__.py" = ["I001"]  # unsorted-imports
 "collagraph/__pyinstaller/*" = ["N999"]  # invalid-module-name
 "collagraph/renderers/**/__init__.py" = ["F401"]  # unused-import
@@ -75,6 +78,9 @@ select = [
     "T20", # flake8-print
     "RUF", # ruff
 ]
+
+[tool.pytest.ini_options]
+addopts = "--benchmark-columns='mean, stddev, rounds'"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -169,3 +169,36 @@ def test_component_element(parse_source):
     assert Example.component is not None
     assert isinstance(Example.component, Example)
     assert Example.component.element is container["children"][0]
+
+
+def test_component_element_behind_control_flow_wrapper(parse_source):
+    """
+    A component whose render root is itself a wrapper (e.g. v-if) around a
+    single element should still resolve `component.element` to that nested
+    element (regression test for ComponentFragment.mount() using
+    `self.first()` instead of a manual BFS over `self.children`).
+    """
+    Example, _ = parse_source(
+        """
+        <el v-if="show" />
+
+        <script>
+        import collagraph as cg
+
+        class Example(cg.Component):
+            component = None
+
+            def mounted(self):
+                Example.component = self
+        </script>
+        """
+    )
+
+    gui = cg.Collagraph(cg.DictRenderer(), event_loop_type=cg.EventLoopType.SYNC)
+    container = {"type": "root"}
+    state = reactive({"show": True})
+    gui.render(Example, container, state=state)
+
+    assert Example.component is not None
+    assert isinstance(Example.component, Example)
+    assert Example.component.element is container["children"][0]

--- a/tests/test_tag_dynamic.py
+++ b/tests/test_tag_dynamic.py
@@ -984,6 +984,80 @@ def test_dynamic_component_with_slot(parse_source):
     assert root["children"][0]["type"] == "content"
 
 
+def test_dynamic_component_tag_switch_updates_correct_owner(parse_source):
+    """
+    Regression test for Fragment._component_parent() caching: when a
+    <component :is="tag"> switches between a plain element and a
+    Component class, the transferred slot content's `updated()`
+    notifications must go to the *new* owning component, not a stale
+    cached owner from before the switch.
+    """
+    Wrapper, _ = parse_source(
+        """
+        <wrapper>
+          <slot />
+        </wrapper>
+        <script>
+        from collagraph import Component
+        class Wrapper(Component):
+            updates = 0
+
+            def updated(self):
+                Wrapper.updates += 1
+        </script>
+        """
+    )
+
+    App, _ = parse_source(
+        """
+        <component :is="tag">
+          <content :text="text" />
+        </component>
+        <script>
+        from collagraph import Component
+        class App(Component):
+            updates = 0
+
+            def updated(self):
+                App.updates += 1
+        </script>
+        """,
+        namespace={"Wrapper": Wrapper},
+    )
+
+    state = reactive({"tag": "div", "text": "Hello"})
+    container = {"type": "root"}
+    gui = Collagraph(
+        renderer=DictRenderer(),
+        event_loop_type=EventLoopType.SYNC,
+    )
+    gui.render(App, container, state=state)
+
+    # Plain element: updates to "content" should be attributed to App
+    App.updates = 0
+    Wrapper.updates = 0
+    state["text"] = "World"
+    assert App.updates == 1
+    assert Wrapper.updates == 0
+
+    # Switch to a Component tag: updates to "content" should now be
+    # attributed to Wrapper, not the stale cached App
+    state["tag"] = Wrapper
+    App.updates = 0
+    Wrapper.updates = 0
+    state["text"] = "Wrapped"
+    assert Wrapper.updates == 1
+    assert App.updates == 0
+
+    # Switch back to a plain element: updates should flow to App again
+    state["tag"] = "section"
+    App.updates = 0
+    Wrapper.updates = 0
+    state["text"] = "Plain again"
+    assert App.updates == 1
+    assert Wrapper.updates == 0
+
+
 def test_dynamic_component_with_named_slots(parse_source):
     """Test dynamic component with Component class that has named slots"""
     Layout, _ = parse_source(


### PR DESCRIPTION
## Summary
- Adds a `pytest-benchmark` suite (`bench/`) covering mount cost, nested-component mount, attribute-update-at-depth, and keyed/unkeyed `v-for` reconciliation, mirroring the sibling `observ` repo's setup.
- Adds `.github/workflows/benchmark.yml`: on PRs, runs the suite against master and against the PR branch, failing the job if mean time regresses >5%.
- Fixes three hot-path inefficiencies in the core rendering code, each verified against the new benchmarks and the full test suite:
  - `weak.py`: the arity check no longer builds a full `inspect.Signature` per callback, just reads `__code__.co_argcount`. ~25-33% faster mounting of elements with dynamic binds.
  - `ComponentFragment.mount()`: replaces a hand-rolled BFS/`deque` with the already-existing `first()` DFS helper. Added a regression test for the wrapped-root case.
  - `Fragment._component_parent()`: now cached instead of walking the parent chain on every attribute update. Flattens `update_at_depth` benchmark scaling from ~5/7.2/15.5µs (depths 10/50/200) to a flat ~4.3µs. Includes an explicit cache-invalidation hook for the one place a mounted fragment is silently reparented (`<component :is="...">` tag switches), with a regression test (`test_dynamic_component_tag_switch_updates_correct_owner`) that fails without the invalidation and passes with it.

## Test plan
- [x] `uv run pytest tests -q` — 266 passed, 14 skipped (up from 264/14 baseline; two new regression tests added)
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run pytest bench --benchmark-only` — all 36 benchmark cases pass
- [x] Verified the `_component_parent` cache-invalidation regression test fails when the invalidation hook is removed, and passes when restored
- [ ] Confirm the new `benchmark.yml` workflow runs successfully in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)