### PR TITLE
Add benchmark suite and per-PR benchmark CI workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,57 @@
+name: Benchmarks
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  benchmark:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync
+
+      # On PRs: run benchmarks twice (PR code vs master code) and compare
+      - name: Run benchmarks
+        run: |
+          # Checkout master version of collagraph directory
+          git fetch origin master
+          git checkout origin/master -- collagraph/
+
+          # Run benchmarks with master code as baseline
+          uv run --no-sync pytest bench \
+              --benchmark-only \
+              --benchmark-save=master \
+              --benchmark-sort=mean || true
+
+          # Restore PR code
+          git checkout HEAD -- collagraph/
+
+          # Run benchmarks on PR code and compare
+          uv run --no-sync pytest bench \
+              --benchmark-only \
+              --benchmark-compare \
+              --benchmark-compare-fail=mean:5% \
+              --benchmark-save=branch \
+              --benchmark-sort=mean
+
+      - name: Upload benchmarks
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Benchmarks
+          path: .benchmarks/
+          include-hidden-files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-groups
       - name: Test
-        run: uv run pytest -v --cov=collagraph --cov-report=term-missing
+        run: uv run pytest tests -v --cov=collagraph --cov-report=term-missing
         env:
           QT_QPA_PLATFORM: offscreen
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 *.spec
 uv.lock
 .venv
+.benchmarks

--- a/bench/conftest.py
+++ b/bench/conftest.py
@@ -1,0 +1,10 @@
+"""Reuse existing test fixtures/helpers for collagraph benchmarks."""
+
+from tests.conftest import (  # noqa: F401
+    CustomElement,
+    CustomElementRenderer,
+    TrackingRenderer,
+    cleanup,
+    parse_source,
+    process_events,
+)

--- a/bench/test_component_mount.py
+++ b/bench/test_component_mount.py
@@ -1,0 +1,66 @@
+"""
+Benchmarks for mounting a chain of nested components.
+
+Each level is its own ComponentFragment, so this stresses per-component
+mount overhead: the weak()-wrapped ref/bind watchers set up in
+ComponentFragment.create(), and the root-element lookup at the end of
+ComponentFragment.mount() (self.first()).
+"""
+
+import pytest
+
+from collagraph import Collagraph, EventLoopType
+from collagraph.renderers import DictRenderer
+
+DEPTHS = [10, 50, 200]
+
+
+def _build_nested_component(parse_source, depth):
+    Leaf, _ = parse_source(
+        """
+        <leaf />
+
+        <script>
+        import collagraph as cg
+
+        class Leaf(cg.Component):
+            pass
+        </script>
+        """
+    )
+
+    prev = Leaf
+    prev_name = "Leaf"
+    for i in range(depth):
+        name = f"Wrapper{i}"
+        prev, _ = parse_source(
+            f"""
+            <div>
+              <{prev_name} />
+            </div>
+
+            <script>
+            import collagraph as cg
+
+            class {name}(cg.Component):
+                pass
+            </script>
+            """,
+            namespace={prev_name: prev},
+        )
+        prev_name = name
+
+    return prev
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="mount_nested_components")
+@pytest.mark.parametrize("depth", DEPTHS, ids=[str(d) for d in DEPTHS])
+def test_mount_nested_components(benchmark, parse_source, depth):
+    App = _build_nested_component(parse_source, depth)
+
+    def mount():
+        gui = Collagraph(renderer=DictRenderer(), event_loop_type=EventLoopType.SYNC)
+        gui.render(App, {"type": "root"})
+
+    benchmark(mount)

--- a/bench/test_creation.py
+++ b/bench/test_creation.py
@@ -1,0 +1,71 @@
+"""
+Benchmarks for the cost of mounting a fragment tree from scratch.
+
+Mounting stresses Fragment.create()/mount(), and for elements with a
+dynamic bind, also the watcher-setup path (`_watch_bind`) which relies
+on the `weak()` decorator for every callback registration.
+"""
+
+import pytest
+from observ import reactive
+
+from collagraph import Collagraph, EventLoopType
+from collagraph.renderers import DictRenderer
+
+SIZES = [10, 100, 1_000]
+SIZE_IDS = ["10", "100", "1k"]
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="mount_plain_elements")
+@pytest.mark.parametrize("n", SIZES, ids=SIZE_IDS)
+def test_mount_plain_elements(benchmark, parse_source, n):
+    children = "\n".join("        <item />" for _ in range(n))
+    App, _ = parse_source(
+        f"""
+        <root>
+{children}
+        </root>
+
+        <script>
+        import collagraph as cg
+
+        class App(cg.Component):
+            pass
+        </script>
+        """
+    )
+
+    def mount():
+        gui = Collagraph(renderer=DictRenderer(), event_loop_type=EventLoopType.SYNC)
+        gui.render(App, {"type": "root"})
+
+    benchmark(mount)
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="mount_bound_elements")
+@pytest.mark.parametrize("n", SIZES, ids=SIZE_IDS)
+def test_mount_bound_elements(benchmark, parse_source, n):
+    children = "\n".join(f'        <item :value="v{i}" />' for i in range(n))
+    App, _ = parse_source(
+        f"""
+        <root>
+{children}
+        </root>
+
+        <script>
+        import collagraph as cg
+
+        class App(cg.Component):
+            pass
+        </script>
+        """
+    )
+    state = reactive({f"v{i}": i for i in range(n)})
+
+    def mount():
+        gui = Collagraph(renderer=DictRenderer(), event_loop_type=EventLoopType.SYNC)
+        gui.render(App, {"type": "root"}, state=state)
+
+    benchmark(mount)

--- a/bench/test_keyed_list.py
+++ b/bench/test_keyed_list.py
@@ -1,0 +1,74 @@
+"""
+Benchmarks for keyed v-for reconciliation.
+
+Stresses ListFragment's keyed reconciliation path: the LIS computation
+and Fragment.anchor() lookups used to reposition/insert fragments.
+
+Each round replaces the whole `items` list in one reactive assignment
+(the idiomatic way to reorder/replace a collection), rather than doing
+many individual in-place mutations, which would each trigger their own
+full reconciliation pass and dominate the measurement with unrelated
+per-mutation dependency-tracking cost.
+"""
+
+import random
+
+import pytest
+from observ import reactive
+
+from collagraph import Collagraph, EventLoopType
+from collagraph.renderers import DictRenderer
+
+SIZES = [10, 100, 1_000]
+SIZE_IDS = ["10", "100", "1k"]
+PATTERNS = ["append", "prepend", "reverse", "shuffle"]
+
+
+def _new_items(items, pattern):
+    if pattern == "append":
+        return [*items, {"id": len(items), "text": "x"}]
+    if pattern == "prepend":
+        return [{"id": len(items), "text": "x"}, *items]
+    if pattern == "reverse":
+        return list(reversed(items))
+    if pattern == "shuffle":
+        shuffled = list(items)
+        random.Random(0).shuffle(shuffled)
+        return shuffled
+    raise ValueError(pattern)
+
+
+def _apply(gui, state, items):
+    # `gui` is unused but must be kept as a live argument: it holds the
+    # only strong reference to the mounted fragment tree, so passing it
+    # through keeps that tree alive for the duration of the timed call.
+    state["items"] = items
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="keyed_list_reconcile")
+@pytest.mark.parametrize("n", SIZES, ids=SIZE_IDS)
+@pytest.mark.parametrize("pattern", PATTERNS)
+def test_keyed_list_reconcile(benchmark, parse_source, pattern, n):
+    App, _ = parse_source(
+        """
+        <node v-for="item in items" :key="item['id']" :text="item['text']" />
+
+        <script>
+        import collagraph as cg
+
+        class App(cg.Component):
+            pass
+        </script>
+        """
+    )
+
+    def setup():
+        initial = [{"id": i, "text": str(i)} for i in range(n)]
+        state = reactive({"items": list(initial)})
+        gui = Collagraph(renderer=DictRenderer(), event_loop_type=EventLoopType.SYNC)
+        gui.render(App, {"type": "root"}, state=state)
+        new_items = _new_items(initial, pattern)
+        return (gui, state, new_items), {}
+
+    benchmark.pedantic(_apply, setup=setup, warmup_rounds=1, rounds=30)

--- a/bench/test_keyed_list.py
+++ b/bench/test_keyed_list.py
@@ -11,6 +11,7 @@ full reconciliation pass and dominate the measurement with unrelated
 per-mutation dependency-tracking cost.
 """
 
+import gc
 import random
 
 import pytest
@@ -42,7 +43,13 @@ def _apply(gui, state, items):
     # `gui` is unused but must be kept as a live argument: it holds the
     # only strong reference to the mounted fragment tree, so passing it
     # through keeps that tree alive for the duration of the timed call.
-    state["items"] = items
+    # GC is disabled during the timed call so that collection pauses
+    # (triggered by the allocation burst) don't dominate the variance.
+    gc.disable()
+    try:
+        state["items"] = items
+    finally:
+        gc.enable()
 
 
 @pytest.mark.timeout(timeout=0)

--- a/bench/test_list_grow.py
+++ b/bench/test_list_grow.py
@@ -1,0 +1,92 @@
+"""
+Benchmarks for growing/shrinking an unkeyed v-for in a single reactive
+assignment.
+
+Growing by n items calls Fragment.anchor() once per appended item, even
+though the anchor is loop-invariant during the update, so these
+benchmarks measure that redundant tree walking. The `siblings` variant
+places a static element after the v-for so that every anchor() call
+also has to resolve an actual sibling element instead of returning
+None.
+"""
+
+import pytest
+from observ import reactive
+
+from collagraph import Collagraph, EventLoopType
+from collagraph.renderers import DictRenderer
+
+SIZES = [100, 1_000]
+SIZE_IDS = ["100", "1k"]
+
+PLAIN_TEMPLATE = """
+<node v-for="item in items" :text="item['text']" />
+
+<script>
+import collagraph as cg
+
+class App(cg.Component):
+    pass
+</script>
+"""
+
+SIBLINGS_TEMPLATE = """
+<template>
+  <header />
+  <node v-for="item in items" :text="item['text']" />
+  <footer />
+</template>
+
+<script>
+import collagraph as cg
+
+class App(cg.Component):
+    pass
+</script>
+"""
+
+
+def _apply(gui, state, items):
+    # `gui` is unused but must be kept as a live argument: it holds the
+    # only strong reference to the mounted fragment tree, so passing it
+    # through keeps that tree alive for the duration of the timed call.
+    state["items"] = items
+
+
+def _setup(parse_source, template, initial_items, target_items):
+    App, _ = parse_source(template)
+
+    def setup():
+        state = reactive({"items": list(initial_items)})
+        gui = Collagraph(renderer=DictRenderer(), event_loop_type=EventLoopType.SYNC)
+        gui.render(App, {"type": "root"}, state=state)
+        return (gui, state, list(target_items)), {}
+
+    return setup
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="unkeyed_list_grow")
+@pytest.mark.parametrize("n", SIZES, ids=SIZE_IDS)
+def test_unkeyed_list_grow(benchmark, parse_source, n):
+    items = [{"text": str(i)} for i in range(n)]
+    setup = _setup(parse_source, PLAIN_TEMPLATE, [], items)
+    benchmark.pedantic(_apply, setup=setup, warmup_rounds=1, rounds=20)
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="unkeyed_list_grow")
+@pytest.mark.parametrize("n", SIZES, ids=SIZE_IDS)
+def test_unkeyed_list_grow_with_siblings(benchmark, parse_source, n):
+    items = [{"text": str(i)} for i in range(n)]
+    setup = _setup(parse_source, SIBLINGS_TEMPLATE, [], items)
+    benchmark.pedantic(_apply, setup=setup, warmup_rounds=1, rounds=20)
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="unkeyed_list_grow")
+@pytest.mark.parametrize("n", SIZES, ids=SIZE_IDS)
+def test_unkeyed_list_shrink(benchmark, parse_source, n):
+    items = [{"text": str(i)} for i in range(n)]
+    setup = _setup(parse_source, PLAIN_TEMPLATE, items, [])
+    benchmark.pedantic(_apply, setup=setup, warmup_rounds=1, rounds=20)

--- a/bench/test_list_grow.py
+++ b/bench/test_list_grow.py
@@ -10,6 +10,8 @@ also has to resolve an actual sibling element instead of returning
 None.
 """
 
+import gc
+
 import pytest
 from observ import reactive
 
@@ -50,7 +52,13 @@ def _apply(gui, state, items):
     # `gui` is unused but must be kept as a live argument: it holds the
     # only strong reference to the mounted fragment tree, so passing it
     # through keeps that tree alive for the duration of the timed call.
-    state["items"] = items
+    # GC is disabled during the timed call so that collection pauses
+    # (triggered by the allocation burst) don't dominate the variance.
+    gc.disable()
+    try:
+        state["items"] = items
+    finally:
+        gc.enable()
 
 
 def _setup(parse_source, template, initial_items, target_items):

--- a/bench/test_unkeyed_list.py
+++ b/bench/test_unkeyed_list.py
@@ -7,6 +7,7 @@ see test_keyed_list.py for why (avoids per-mutation reconciliation cost
 from dominating the measurement).
 """
 
+import gc
 import random
 
 import pytest
@@ -38,7 +39,13 @@ def _apply(gui, state, items):
     # `gui` is unused but must be kept as a live argument: it holds the
     # only strong reference to the mounted fragment tree, so passing it
     # through keeps that tree alive for the duration of the timed call.
-    state["items"] = items
+    # GC is disabled during the timed call so that collection pauses
+    # (triggered by the allocation burst) don't dominate the variance.
+    gc.disable()
+    try:
+        state["items"] = items
+    finally:
+        gc.enable()
 
 
 @pytest.mark.timeout(timeout=0)

--- a/bench/test_unkeyed_list.py
+++ b/bench/test_unkeyed_list.py
@@ -1,0 +1,70 @@
+"""
+Benchmarks for unkeyed v-for reconciliation (index-based), for comparison
+against the keyed reconciliation path in test_keyed_list.py.
+
+Each round replaces the whole `items` list in one reactive assignment,
+see test_keyed_list.py for why (avoids per-mutation reconciliation cost
+from dominating the measurement).
+"""
+
+import random
+
+import pytest
+from observ import reactive
+
+from collagraph import Collagraph, EventLoopType
+from collagraph.renderers import DictRenderer
+
+SIZES = [10, 100, 1_000]
+SIZE_IDS = ["10", "100", "1k"]
+PATTERNS = ["append", "prepend", "reverse", "shuffle"]
+
+
+def _new_items(items, pattern):
+    if pattern == "append":
+        return [*items, {"text": "x"}]
+    if pattern == "prepend":
+        return [{"text": "x"}, *items]
+    if pattern == "reverse":
+        return list(reversed(items))
+    if pattern == "shuffle":
+        shuffled = list(items)
+        random.Random(0).shuffle(shuffled)
+        return shuffled
+    raise ValueError(pattern)
+
+
+def _apply(gui, state, items):
+    # `gui` is unused but must be kept as a live argument: it holds the
+    # only strong reference to the mounted fragment tree, so passing it
+    # through keeps that tree alive for the duration of the timed call.
+    state["items"] = items
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="unkeyed_list_reconcile")
+@pytest.mark.parametrize("n", SIZES, ids=SIZE_IDS)
+@pytest.mark.parametrize("pattern", PATTERNS)
+def test_unkeyed_list_reconcile(benchmark, parse_source, pattern, n):
+    App, _ = parse_source(
+        """
+        <node v-for="item in items" :text="item['text']" />
+
+        <script>
+        import collagraph as cg
+
+        class App(cg.Component):
+            pass
+        </script>
+        """
+    )
+
+    def setup():
+        initial = [{"text": str(i)} for i in range(n)]
+        state = reactive({"items": list(initial)})
+        gui = Collagraph(renderer=DictRenderer(), event_loop_type=EventLoopType.SYNC)
+        gui.render(App, {"type": "root"}, state=state)
+        new_items = _new_items(initial, pattern)
+        return (gui, state, new_items), {}
+
+    benchmark.pedantic(_apply, setup=setup, warmup_rounds=1, rounds=30)

--- a/bench/test_update_depth.py
+++ b/bench/test_update_depth.py
@@ -1,0 +1,48 @@
+"""
+Benchmarks for updating a single reactive prop on a leaf element nested at
+varying depth.
+
+Every attribute update on a mounted fragment calls
+Fragment._component_parent() to find the owning component's `updated()`
+hook, which walks the parent chain. This stresses that walk relative to
+tree depth.
+"""
+
+import pytest
+from observ import reactive
+
+from collagraph import Collagraph, EventLoopType
+from collagraph.renderers import DictRenderer
+
+DEPTHS = [10, 50, 200]
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="update_at_depth")
+@pytest.mark.parametrize("depth", DEPTHS, ids=[str(d) for d in DEPTHS])
+def test_update_attribute_at_depth(benchmark, parse_source, depth):
+    open_tags = "<div>" * depth
+    close_tags = "</div>" * depth
+    App, _ = parse_source(
+        f"""
+        {open_tags}<leaf :value="value" />{close_tags}
+
+        <script>
+        import collagraph as cg
+
+        class App(cg.Component):
+            pass
+        </script>
+        """
+    )
+    state = reactive({"value": 0})
+    gui = Collagraph(renderer=DictRenderer(), event_loop_type=EventLoopType.SYNC)
+    gui.render(App, {"type": "root"}, state=state)
+
+    counter = {"i": 0}
+
+    def update():
+        counter["i"] += 1
+        state["value"] = counter["i"]
+
+    benchmark(update)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ dev = [
     "colorlog",
     "pre-commit",
     "pytest",
+    "pytest-benchmark",
     "pytest-cov",
+    "pytest-timeout",
     "rich",
     "ruff",
     "twine",
@@ -51,6 +53,7 @@ pyside-dev = [
 # pygfx = { git = "https://github.com/pygfx/pygfx" }
 
 [tool.ruff.lint.per-file-ignores]
+"bench/*" = ["F821", "N806"]  # undefined-name, non-lowercase-variable-in-function
 "collagraph/__init__.py" = ["I001"]  # unsorted-imports
 "collagraph/__pyinstaller/*" = ["N999"]  # invalid-module-name
 "collagraph/renderers/**/__init__.py" = ["F401"]  # unused-import
@@ -75,6 +78,9 @@ select = [
     "T20", # flake8-print
     "RUF", # ruff
 ]
+
+[tool.pytest.ini_options]
+addopts = "--benchmark-columns='mean, stddev, rounds'"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary
First PR of the performance series that supersedes #183 (split so each optimization is proven independently by CI).

- Adds a `pytest-benchmark` suite under `bench/`, mirroring the sibling `observ` repo's setup. Scenarios: plain/bound element creation (10/100/1000), nested component mount (depth 10/50/200), attribute update at depth (10/50/200), keyed and unkeyed `v-for` reconciliation (append/prepend/reverse/shuffle × 10/100/1000), and a new unkeyed list grow/shrink scenario (100/1000, with and without sibling elements) that exposes the current O(n²) anchor recomputation when appending items.
- Adds `.github/workflows/benchmark.yml`: on every PR it runs the suite against the master version of `collagraph/` and against the PR version, fails when mean time regresses >5%, and uploads `.benchmarks/` as an artifact. All benchmarks use `DictRenderer` + a synchronous event loop, so no Qt/GL system dependencies are needed.
- Scopes the CI test job to `tests` so the 5-way Python matrix no longer collects the benchmark suite.
- Adds `pytest-benchmark`/`pytest-timeout` to the dev group, benchmark display columns, a ruff per-file ignore for `bench/*`, and gitignores `.benchmarks/`.

Since this PR does not touch `collagraph/` source, the benchmark workflow on this PR compares identical code and should report ~0% deltas — validating the pipeline itself. Follow-up PRs with the actual optimizations will then show their gains automatically in this workflow.

## Test plan
- [x] `uv run pytest tests -q` — 349 passed, 1 skipped
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run pytest bench --collect-only` — 42 benchmarks collected; new grow/shrink benchmarks run green locally
- [ ] Benchmark workflow passes on this PR with ~0% deltas
- [ ] CI test matrix no longer collects `bench/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)