### PR TITLE
Add docs badge and links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,8 @@ Here is an example that shows a counter, made with a component with Vue-like syn
 Contents of `counter.cgx`:
 ```html
 <widget>
-  <label
-    :text="f'Count: {count}'"
-  />
-  <button
-    text="bump"
-    @clicked="bump"
-  />
+  <label>Count: {{ count }}</label>
+  <button @clicked="bump">bump</button>
 </widget>
 
 <script>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Write your Python interfaces in a declarative manner as single-file components w
 * Fine-grained reactivity (made possible by leveraging [observ](https://github.com/fork-tongue/observ))
 * Class components with local state and life-cycle methods/hooks
 * Single-file components with Vue-like template syntax (`.cgx` files)
-* Custom renderers
+* Renderers for PySide6 and [Pygfx](https://github.com/pygfx/pygfx), with support for custom renderers
 
 Here is an example that shows a counter, made with a component with Vue-like syntax:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![PyPI version](https://badge.fury.io/py/collagraph.svg)](https://badge.fury.io/py/collagraph)
 [![CI status](https://github.com/fork-tongue/collagraph/workflows/CI/badge.svg)](https://github.com/fork-tongue/collagraph/actions)
+[![Docs](https://github.com/fork-tongue/collagraph/workflows/Docs/badge.svg)](https://fork-tongue.github.io/collagraph/)
 
 # Collagraph 📓
 
@@ -7,7 +8,7 @@ Reactive user interfaces.
 
 > The word [Collagraphy](https://en.wikipedia.org/wiki/Collagraphy) is derived from the Greek word _koll_ or _kolla_, meaning glue, and graph, meaning the activity of drawing.
 
-Inspired by Vue and React.
+Inspired by Vue and React. Check out the [documentation](https://fork-tongue.github.io/collagraph/) to get started.
 
 
 ## Features
@@ -81,7 +82,7 @@ To inspect the Python code that is compiled for a component, use the `--show-cod
 uv run collagraph --show-code examples/pyside/counter.cgx
 ```
 
-For more examples, please take a look at the [examples folder](examples).
+For more examples, please take a look at the [examples folder](examples). For guides and API reference, visit the [documentation](https://fork-tongue.github.io/collagraph/).
 
 Currently there are two renderers:
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Inspired by Vue and React. Check out the [documentation](https://fork-tongue.git
 
 ## Features
 
-Write your Python interfaces in a declarative manner with plain render functions, component classes or even single-file components using Vue-like syntax, but with Python!
+Write your Python interfaces in a declarative manner as single-file components with Vue-like syntax (`.cgx` files), but with Python!
 
-* Reactivity (made possible by leveraging [observ](https://github.com/fork-tongue/observ))
+* Fine-grained reactivity (made possible by leveraging [observ](https://github.com/fork-tongue/observ))
 * Class components with local state and life-cycle methods/hooks
 * Single-file components with Vue-like template syntax (`.cgx` files)
 * Custom renderers


### PR DESCRIPTION
The documentation is now live at https://fork-tongue.github.io/collagraph/, so link to it from the README:

- A **Docs** badge next to the PyPI and CI badges, showing the status of the Docs workflow and linking to the live documentation site
- A link to the documentation in the intro
- A link to the guides/API reference next to the existing examples-folder pointer

Also includes two README refreshes:

- Update the counter example to use text interpolation (`<label>Count: {{ count }}</label>`), matching `examples/pyside/counter.cgx` and the documentation
- Remove the outdated mention of plain render functions: since the fine-grained reactivity overhaul, single-file components (`.cgx`) are the ergonomic way to write components

🤖 Generated with [Claude Code](https://claude.com/claude-code)