### PR TITLE
Add pure-Python view API as alternative to cgx templates

### DIFF
--- a/collagraph/__init__.py
+++ b/collagraph/__init__.py
@@ -6,9 +6,9 @@ from .constants import EventLoopType  # noqa: F401
 from .dsl import (  # noqa: F401
     dynamic,
     each,
-    elif_,
     fill,
     h,
+    or_when,
     otherwise,
     slot,
     static,

--- a/collagraph/__init__.py
+++ b/collagraph/__init__.py
@@ -3,6 +3,17 @@ from importlib.metadata import version
 from .collagraph import Collagraph  # noqa: F401
 from .component import Component  # noqa: F401
 from .constants import EventLoopType  # noqa: F401
+from .dsl import (  # noqa: F401
+    dynamic,
+    each,
+    elif_,
+    fill,
+    h,
+    otherwise,
+    slot,
+    static,
+    when,
+)
 from .renderers import *  # noqa: F403
 from .sfc import importer  # noqa: F401
 

--- a/collagraph/__main__.py
+++ b/collagraph/__main__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import importlib
 import json
+import sys
 from pathlib import Path
 
 from observ import reactive
@@ -25,15 +26,74 @@ def available_renderers():
     return result
 
 
+def load_component_class(component_path: Path, class_name: str | None = None):
+    """Import a component file (.cgx or .py) and return its root component class."""
+    if component_path.suffix == ".cgx":
+        file_as_module = ".".join([*component_path.parts[:-1], component_path.stem])
+        component_module = importlib.import_module(file_as_module)
+        return component_module.__component_class
+
+    # Plain Python module with view component(s): import it by its stem,
+    # with its directory on sys.path so sibling imports work
+    directory = str(component_path.parent.resolve())
+    if directory not in sys.path:
+        sys.path.insert(0, directory)
+    module = importlib.import_module(component_path.stem)
+    module_file = getattr(module, "__file__", None)
+    if module_file is None or Path(module_file).resolve() != component_path.resolve():
+        raise SystemExit(
+            f"Cannot import {component_path}: the module name "
+            f"{component_path.stem!r} is already taken by {module_file!r}. "
+            "Rename the file to something unique."
+        )
+    return find_view_component_class(module, class_name, component_path)
+
+
+def find_view_component_class(module, class_name: str | None, component_path: Path):
+    """Find the root view component class in a plain Python module."""
+    if class_name is not None:
+        cls = getattr(module, class_name, None)
+        if not (isinstance(cls, type) and issubclass(cls, cg.Component)):
+            raise SystemExit(
+                f"{component_path}: {class_name!r} is not a Component subclass"
+            )
+        return cls
+
+    # Allow modules to mark their root component explicitly,
+    # like compiled .cgx modules do
+    explicit = getattr(module, "__component_class", None)
+    if explicit is not None:
+        return explicit
+
+    candidates = [
+        attr
+        for attr in vars(module).values()
+        if isinstance(attr, type)
+        and issubclass(attr, cg.Component)
+        and attr is not cg.Component
+        and attr.__module__ == module.__name__
+        and attr.view is not cg.Component.view
+    ]
+    if len(candidates) == 1:
+        return candidates[0]
+    if not candidates:
+        raise SystemExit(f"No view component found in {component_path}")
+    names = ", ".join(cls.__name__ for cls in candidates)
+    hint = f"{component_path}:{candidates[-1].__name__}"
+    raise SystemExit(
+        f"Multiple view components found in {component_path}: {names}. "
+        f"Select one by appending the class name: {hint}"
+    )
+
+
 def init_collagraph(
     renderer_type: str,
     component_path: Path,
     state: dict | None = None,
     hot_reload: bool = False,
+    class_name: str | None = None,
 ):
-    file_as_module = ".".join([*component_path.parts[:-1], component_path.stem])
-    component_module = importlib.import_module(file_as_module)
-    component_class = component_module.__component_class
+    component_class = load_component_class(component_path, class_name)
     props = reactive(state or {})
 
     if renderer_type == "pygfx":
@@ -91,13 +151,24 @@ def show_code(component_path: Path):
 
 def existing_component_file(value):
     path = Path(value)
+    class_name = None
+    if not path.exists() and ":" in value:
+        # Allow selecting a component class: path/to/module.py:ClassName
+        path_str, _, name = value.rpartition(":")
+        if name.isidentifier():
+            path = Path(path_str)
+            class_name = name
     if not path.exists():
         raise argparse.ArgumentTypeError(f"{value} does not exist")
     if not path.is_file():
         raise argparse.ArgumentTypeError(f"{value} is not a file")
-    if path.suffix != ".cgx":
+    if path.suffix not in (".cgx", ".py"):
         raise argparse.ArgumentTypeError(f"{value} is not a collagraph component")
-    return path
+    if class_name and path.suffix != ".py":
+        raise argparse.ArgumentTypeError(
+            f"{value}: selecting a component class is only supported for .py files"
+        )
+    return path, class_name
 
 
 def json_contents(value):
@@ -134,7 +205,10 @@ def run():
     parser.add_argument(
         "component",
         type=existing_component_file,
-        help="Path to component to render",
+        help=(
+            "Path to component to render: a .cgx file or a .py module "
+            "with a view component (append :ClassName to select a class)"
+        ),
     )
     parser.add_argument(
         "--hot-reload",
@@ -148,12 +222,21 @@ def run():
         help="Pretty print the compiled Python code for the component and exit",
     )
     args = parser.parse_args()
+    component_path, class_name = args.component
 
     if args.show_code:
-        show_code(args.component)
+        if component_path.suffix != ".cgx":
+            parser.error("--show-code is only supported for .cgx files")
+        show_code(component_path)
         return
 
-    init_collagraph(args.renderer, args.component, args.state, args.hot_reload)
+    init_collagraph(
+        args.renderer,
+        component_path,
+        args.state,
+        args.hot_reload,
+        class_name=class_name,
+    )
 
 
 if __name__ == "__main__":

--- a/collagraph/component.py
+++ b/collagraph/component.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import abstractmethod
 from collections import defaultdict
 from typing import TYPE_CHECKING, ClassVar
 from weakref import ref
@@ -117,8 +116,30 @@ class Component:
         """
         pass
 
-    @abstractmethod
-    def render(self, renderer: Renderer) -> ComponentFragment:  # pragma: no cover
+    def render(self, renderer: Renderer) -> ComponentFragment:
+        """Build the fragment tree for this component.
+
+        Components defined in a .cgx file get a compiled implementation of
+        this method injected. Pure-Python components implement `view`
+        instead, which is picked up here.
+        """
+        if type(self).view is not Component.view:
+            from .dsl import build_view
+
+            return build_view(self, renderer)
+        raise NotImplementedError(
+            f"{type(self).__name__} defines neither a template (.cgx) "
+            "nor a `view` method"
+        )
+
+    def view(self) -> None:
+        """Describe the UI of this component with the pure-Python view API.
+
+        Runs once, when the component is created. Build the element tree
+        with `collagraph.h` and the control flow helpers (`when`, `each`,
+        ...); pass callables for any value that should update reactively.
+        See `collagraph.dsl` for the full API.
+        """
         raise NotImplementedError
 
     def provide(self, key: str, value):

--- a/collagraph/dsl.py
+++ b/collagraph/dsl.py
@@ -38,7 +38,7 @@ Positional arguments to an element become text children: plain strings are
 static text, callables are live text (the equivalent of ``{{ expression }}``).
 
 Control flow (``v-if``/``v-else-if``/``v-else``) is expressed with ``when``,
-``elif_`` and ``otherwise``; list rendering (``v-for``) with the ``each``
+``or_when`` and ``otherwise``; list rendering (``v-for``) with the ``each``
 decorator. Slots are declared with ``slot`` and filled with ``fill``. Dynamic
 components (``<component :is="...">``) are created with ``dynamic``.
 """
@@ -78,7 +78,7 @@ class _Frame:
 
     def __init__(self, fragment: Fragment):
         self.fragment = fragment
-        # The 'open' ControlFlowFragment that a subsequent elif_/otherwise
+        # The 'open' ControlFlowFragment that a subsequent or_when/otherwise
         # at this nesting level would attach to. Reset whenever a regular
         # sibling element is added (mirrors how adjacency of v-if/v-else-if/
         # v-else works in templates).
@@ -214,7 +214,7 @@ def _element(
         fragment = Fragment(builder.renderer, tag=tag)
     _apply_props(fragment, props)
     _attach(builder, fragment)
-    # A regular sibling breaks any open when/elif_ chain
+    # A regular sibling breaks any open when/or_when chain
     builder.frame.control_flow = None
     _add_text_children(builder, fragment, children)
     return _Node(fragment, builder)
@@ -282,14 +282,14 @@ def when(condition: Callable[[], Any]) -> _Node:
     return _branch(builder, control_flow, condition)
 
 
-def elif_(condition: Callable[[], Any]) -> _Node:
+def or_when(condition: Callable[[], Any]) -> _Node:
     """Add an else-if branch (``v-else-if``) to the directly preceding
     `when` block."""
-    assert callable(condition), "elif_() takes a callable, e.g. lambda: state['x']"
+    assert callable(condition), "or_when() takes a callable, e.g. lambda: state['x']"
     builder = _current_builder()
     control_flow = builder.frame.control_flow
     if control_flow is None:
-        raise RuntimeError("elif_() must directly follow a when() or elif_() block")
+        raise RuntimeError("or_when() must directly follow a when() or or_when() block")
     return _branch(builder, control_flow, condition)
 
 
@@ -299,7 +299,9 @@ def otherwise() -> _Node:
     builder = _current_builder()
     control_flow = builder.frame.control_flow
     if control_flow is None:
-        raise RuntimeError("otherwise() must directly follow a when() or elif_() block")
+        raise RuntimeError(
+            "otherwise() must directly follow a when() or or_when() block"
+        )
     # The chain is complete: nothing can attach to it anymore
     builder.frame.control_flow = None
     return _branch(builder, control_flow, None)

--- a/collagraph/dsl.py
+++ b/collagraph/dsl.py
@@ -1,0 +1,485 @@
+"""
+Pure-Python view API for collagraph components.
+
+Instead of writing a .cgx template, components can describe their UI in a
+`view` method using the element builder `h` together with the control flow
+helpers from this module. The view method runs *once* when the component is
+created (like a compiled .cgx render function); fine-grained reactivity is
+achieved by passing zero-argument callables for anything dynamic.
+
+The one rule to remember: **a plain value is static, a callable is live**.
+
+    import collagraph as cg
+    from collagraph import h
+
+
+    class Counter(cg.Component):
+        def init(self):
+            self.state["count"] = 0
+
+        def bump(self):
+            self.state["count"] += 1
+
+        def view(self):
+            with h.widget():
+                h.label(text=lambda: f"Count: {self.state['count']}")
+                h.button("bump", on_clicked=self.bump)
+
+Keyword arguments to an element map onto the fragment API as follows:
+
+* plain value: static attribute (``set_attribute``)
+* callable: reactive bind (``set_bind``)
+* ``on_<event>``: event handler (``set_event``)
+* ``bind``: callable returning a dict of attributes (``set_bind_dict``),
+  the pure-Python equivalent of ``v-bind="dict"``
+* ``ref``: template ref (string or callable)
+
+Positional arguments to an element become text children: plain strings are
+static text, callables are live text (the equivalent of ``{{ expression }}``).
+
+Control flow (``v-if``/``v-else-if``/``v-else``) is expressed with ``when``,
+``elif_`` and ``otherwise``; list rendering (``v-for``) with the ``each``
+decorator. Slots are declared with ``slot`` and filled with ``fill``. Dynamic
+components (``<component :is="...">``) are created with ``dynamic``.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from inspect import signature
+from typing import Any
+from warnings import warn
+from weakref import ref
+
+from .component import Component
+from .fragment import (
+    ComponentFragment,
+    ControlFlowFragment,
+    DynamicFragment,
+    Fragment,
+    ListFragment,
+    SlotFragment,
+)
+from .renderers import Renderer
+
+# Adjust this setting to disable some runtime checks
+# Defaults to True, except when it is part of an installed application
+DSL_RUNTIME_WARNINGS = not getattr(sys, "frozen", False)
+
+EVENT_PREFIX = "on_"
+BIND_DICT_KEY = "bind"
+
+
+class _Frame:
+    """One level of nesting in the view being built."""
+
+    __slots__ = ("control_flow", "fragment")
+
+    def __init__(self, fragment: Fragment):
+        self.fragment = fragment
+        # The 'open' ControlFlowFragment that a subsequent elif_/otherwise
+        # at this nesting level would attach to. Reset whenever a regular
+        # sibling element is added (mirrors how adjacency of v-if/v-else-if/
+        # v-else works in templates).
+        self.control_flow: ControlFlowFragment | None = None
+
+
+class _Builder:
+    """Tracks the fragment tree under construction for one view (or one
+    generated list item)."""
+
+    __slots__ = ("frames", "renderer")
+
+    def __init__(self, renderer: Renderer):
+        self.renderer = renderer
+        self.frames: list[_Frame] = []
+
+    @property
+    def frame(self) -> _Frame:
+        return self.frames[-1]
+
+
+# Stack of active builders. A plain list suffices: views are built
+# synchronously, and list item factories (which run later, during mount
+# and updates) push their own builder.
+_builders: list[_Builder] = []
+
+
+def _current_builder() -> _Builder:
+    if not _builders:
+        raise RuntimeError(
+            "No view is being built: h() and the other view functions can "
+            "only be called (directly or indirectly) from a component's "
+            "`view` method"
+        )
+    return _builders[-1]
+
+
+def _is_component_usage(fragment: Fragment) -> bool:
+    """Whether the fragment is a component usage site (children of which
+    become slot content)."""
+    return isinstance(fragment, ComponentFragment) and fragment.tag is not None
+
+
+def _attach(builder: _Builder, fragment: Fragment, slot_name: str | None = None):
+    """Attach a newly built fragment to the current parent.
+
+    Children of a component usage site become slot content: their slot name
+    has to be set *before* registering with the parent.
+    """
+    parent = builder.frame.fragment
+    if _is_component_usage(parent):
+        fragment.slot_name = slot_name or fragment.slot_name or "default"
+    fragment._parent = ref(parent)
+    parent.register_child(fragment)
+
+
+class _Node:
+    """Handle to a built fragment. Can be used as context manager to nest
+    child elements."""
+
+    __slots__ = ("_builder", "fragment")
+
+    def __init__(self, fragment: Fragment, builder: _Builder):
+        self.fragment = fragment
+        self._builder = builder
+
+    def __enter__(self) -> _Node:
+        self._builder.frames.append(_Frame(self.fragment))
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        frame = self._builder.frames.pop()
+        assert frame.fragment is self.fragment
+        return False
+
+
+class _Static:
+    """Marks a callable that should be treated as a static attribute value
+    instead of a reactive bind. See `static`."""
+
+    __slots__ = ("value",)
+
+    def __init__(self, value):
+        self.value = value
+
+
+def static(value) -> _Static:
+    """Wrap a callable to pass it as a static attribute value.
+
+    By default a callable attribute value creates a reactive bind. Use this
+    to pass an actual function object as a (non-event) attribute instead:
+
+        h.item(sort_function=cg.static(natural_sort))
+    """
+    return _Static(value)
+
+
+def _apply_props(fragment: Fragment, props: dict[str, Any]):
+    for key, value in props.items():
+        if key.startswith(EVENT_PREFIX) and len(key) > len(EVENT_PREFIX):
+            fragment.set_event(key[len(EVENT_PREFIX) :], value)
+        elif key == BIND_DICT_KEY and callable(value):
+            fragment.set_bind_dict(BIND_DICT_KEY, value)
+        elif isinstance(value, _Static):
+            fragment.set_attribute(key, value.value)
+        elif callable(value):
+            fragment.set_bind(key, value)
+        else:
+            fragment.set_attribute(key, value)
+
+
+def _add_text_children(
+    builder: _Builder, fragment: Fragment, children: tuple[Any, ...]
+):
+    for child in children:
+        text = Fragment(builder.renderer, tag="TEXT_ELEMENT")
+        if callable(child):
+            text.set_bind("content", child)
+        else:
+            text.set_attribute("content", child)
+        text._parent = ref(fragment)
+        fragment.register_child(text)
+
+
+def _element(
+    tag: str | type[Component], children: tuple[Any, ...], props: dict[str, Any]
+) -> _Node:
+    builder = _current_builder()
+    is_component = isinstance(tag, type) and issubclass(tag, Component)
+    if is_component:
+        fragment: Fragment = ComponentFragment(builder.renderer, tag=tag)
+    else:
+        fragment = Fragment(builder.renderer, tag=tag)
+    _apply_props(fragment, props)
+    _attach(builder, fragment)
+    # A regular sibling breaks any open when/elif_ chain
+    builder.frame.control_flow = None
+    _add_text_children(builder, fragment, children)
+    return _Node(fragment, builder)
+
+
+class _TagBuilder:
+    """Bound element builder for a specific tag: `h.widget` etc."""
+
+    __slots__ = ("tag",)
+
+    def __init__(self, tag: str):
+        self.tag = tag
+
+    def __call__(self, *children, **props) -> _Node:
+        return _element(self.tag, children, props)
+
+
+class _H:
+    """Element builder.
+
+    * ``h("widget", ...)`` or ``h.widget(...)``: element with a string tag
+    * ``h(MyComponent, ...)``: child component
+    """
+
+    def __call__(self, tag: str | type[Component], *children, **props) -> _Node:
+        return _element(tag, children, props)
+
+    def __getattr__(self, tag: str) -> _TagBuilder:
+        if tag.startswith("_"):
+            raise AttributeError(tag)
+        return _TagBuilder(tag)
+
+
+h = _H()
+
+
+def _branch(
+    builder: _Builder,
+    control_flow: ControlFlowFragment,
+    condition: Callable[[], Any] | None,
+) -> _Node:
+    # Branches can hold multiple children, so each branch is wrapped in a
+    # virtual (tag-less) fragment which carries the condition.
+    branch = Fragment(builder.renderer, tag=None, parent=control_flow)
+    if condition is not None:
+        branch.set_condition(lambda: bool(condition()))
+    return _Node(branch, builder)
+
+
+def when(condition: Callable[[], Any]) -> _Node:
+    """Start a conditional block (``v-if``).
+
+    Content built inside the returned context manager is only rendered while
+    the condition evaluates to a truthy value:
+
+        with cg.when(lambda: self.state["ready"]):
+            h.label(text="Ready!")
+    """
+    assert callable(condition), "when() takes a callable, e.g. lambda: state['x']"
+    builder = _current_builder()
+    frame = builder.frame
+    control_flow = ControlFlowFragment(builder.renderer)
+    _attach(builder, control_flow)
+    frame.control_flow = control_flow
+    return _branch(builder, control_flow, condition)
+
+
+def elif_(condition: Callable[[], Any]) -> _Node:
+    """Add an else-if branch (``v-else-if``) to the directly preceding
+    `when` block."""
+    assert callable(condition), "elif_() takes a callable, e.g. lambda: state['x']"
+    builder = _current_builder()
+    control_flow = builder.frame.control_flow
+    if control_flow is None:
+        raise RuntimeError("elif_() must directly follow a when() or elif_() block")
+    return _branch(builder, control_flow, condition)
+
+
+def otherwise() -> _Node:
+    """Add an else branch (``v-else``) to the directly preceding `when`
+    block."""
+    builder = _current_builder()
+    control_flow = builder.frame.control_flow
+    if control_flow is None:
+        raise RuntimeError("otherwise() must directly follow a when() or elif_() block")
+    # The chain is complete: nothing can attach to it anymore
+    builder.frame.control_flow = None
+    return _branch(builder, control_flow, None)
+
+
+def each(expression: Callable[[], Any], key: Callable[[Any], Any] | None = None):
+    """Render an item of content for each value of a reactive collection
+    (``v-for``).
+
+    Used as a decorator on a function that builds the content for a single
+    item. The function receives one *getter* per loop variable: a
+    zero-argument callable returning the current value (call it inside your
+    lambdas, so that the read happens when the binding updates):
+
+        @cg.each(lambda: self.state["items"], key=lambda item: item["id"])
+        def _(item):
+            h.label(text=lambda: item()["text"])
+
+    Multiple loop variables work through the function signature, like tuple
+    unpacking in a for statement:
+
+        @cg.each(lambda: enumerate(self.state["items"]))
+        def _(i, item):
+            h.label(text=lambda: f"{i()}: {item()}")
+
+    The `key` function (``:key``) receives the whole item value and must
+    return a unique, stable identifier; providing it enables keyed
+    reconciliation (efficient reordering).
+    """
+    assert callable(expression), "each() takes a callable, e.g. lambda: state['items']"
+    builder = _current_builder()
+    renderer = builder.renderer
+    list_fragment = ListFragment(renderer)
+    _attach(builder, list_fragment)
+    builder.frame.control_flow = None
+
+    def decorator(fn: Callable) -> Callable:
+        arity = len(
+            [
+                param
+                for param in signature(fn).parameters.values()
+                if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD)
+            ]
+        )
+        if arity == 0:
+            raise TypeError(
+                "each() requires a function with at least one parameter "
+                "(the loop variable getter)"
+            )
+
+        def create_fragment(context: Callable[[], Any]) -> Fragment:
+            wrapper = Fragment(renderer, tag=None)
+            if arity == 1:
+                getters: tuple[Callable[[], Any], ...] = (context,)
+            else:
+                getters = tuple((lambda i=i: context()[i]) for i in range(arity))
+            nested = _Builder(renderer)
+            nested.frames.append(_Frame(wrapper))
+            _builders.append(nested)
+            try:
+                _call_view_code(lambda: fn(*getters), fn)
+            finally:
+                _builders.pop()
+            return wrapper
+
+        key_extractor = None
+        if key is not None:
+
+            def key_extractor(context, _key=key):
+                # ListFragment passes a getter for the item
+                return _key(context())
+
+        list_fragment.set_create_fragment(
+            create_fragment, is_keyed=key is not None, key_extractor=key_extractor
+        )
+        list_fragment.set_expression(expression)
+        return fn
+
+    return decorator
+
+
+def slot(name: str = "default") -> _Node:
+    """Declare a slot (``<slot>``) at this location in the view.
+
+    Content that the parent component provides for this slot name is
+    rendered here. Fallback content can be nested inside:
+
+        with cg.slot("header"):
+            h.label(text="default header")
+    """
+    builder = _current_builder()
+    parent = builder.frame.fragment
+    fragment = SlotFragment(builder.renderer, name=name, parent=parent)
+    builder.frame.control_flow = None
+    return _Node(fragment, builder)
+
+
+def fill(name: str = "default") -> _Node:
+    """Provide content for a named slot of the surrounding component
+    (``<template v-slot:name>``):
+
+        with h(Layout):
+            with cg.fill("header"):
+                h.label(text="header content")
+
+    Content built directly inside a component element (without `fill`) goes
+    to the "default" slot.
+    """
+    builder = _current_builder()
+    parent = builder.frame.fragment
+    if not _is_component_usage(parent):
+        raise RuntimeError(
+            "fill() can only be used directly inside a component element"
+        )
+    fragment = Fragment(builder.renderer, tag="template")
+    _attach(builder, fragment, slot_name=name)
+    builder.frame.control_flow = None
+    return _Node(fragment, builder)
+
+
+def dynamic(is_: Callable[[], Any], *children, **props) -> _Node:
+    """Create a dynamic element/component (``<component :is="...">``).
+
+    The callable determines the tag: it can return a component class or a
+    string tag, and the element is swapped out reactively when the value
+    changes."""
+    assert callable(is_), "dynamic() takes a callable, e.g. lambda: state['view']"
+    builder = _current_builder()
+    fragment = DynamicFragment(builder.renderer, expression=is_)
+    _apply_props(fragment, props)
+    _attach(builder, fragment)
+    builder.frame.control_flow = None
+    _add_text_children(builder, fragment, children)
+    return _Node(fragment, builder)
+
+
+def _call_view_code(fn: Callable[[], Any], source: Any):
+    """Call view-building code, guarding against eager reactive reads.
+
+    Correct view code performs *no* reactive reads while it runs: all reads
+    of state/props belong inside the lambdas passed to elements. An eager
+    read is almost always a bug (the value would be baked in statically), so
+    detect it by running the code as a (temporary) watcher and checking
+    whether any dependencies were recorded.
+
+    Wrapping in a watcher also shields any surrounding watcher (e.g. the one
+    that re-mounts a conditional block) from accidentally picking up those
+    reads as dependencies.
+    """
+    if not DSL_RUNTIME_WARNINGS:
+        fn()
+        return
+
+    from observ.watcher import Watcher
+
+    watcher = Watcher(fn)
+    try:
+        watcher.get()
+        if watcher._deps:
+            warn(
+                f"Reactive value read during view build: {source}.\n"
+                "Reads of state/props directly in view code are evaluated "
+                "only once and will not update. Wrap the expression in a "
+                "lambda to make it reactive, e.g.:\n"
+                "  h.label(text=lambda: self.state['count'])"
+            )
+    finally:
+        watcher.stop()
+
+
+def build_view(component: Component, renderer: Renderer) -> ComponentFragment:
+    """Build the fragment tree for a component that defines a `view` method.
+
+    Called by the default `Component.render` implementation."""
+    root = ComponentFragment(renderer)
+    builder = _Builder(renderer)
+    builder.frames.append(_Frame(root))
+    _builders.append(builder)
+    try:
+        _call_view_code(component.view, component)
+    finally:
+        _builders.pop()
+    return root

--- a/collagraph/hot_reload.py
+++ b/collagraph/hot_reload.py
@@ -7,6 +7,7 @@ Provides file watching and module reloading for .cgx single-file components.
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import logging
 import sys
 import threading
@@ -18,6 +19,8 @@ import colorlog
 from observ import to_raw
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from collagraph import Collagraph
     from collagraph.fragment import Fragment
 
@@ -223,6 +226,10 @@ class HotReloader:
         self._gui_ref = weakref.ref(gui)
         self._watched_modules: dict[Path, str] = {}  # path -> module_name
         self._root_module_name: str | None = None
+        self._root_class_name: str | None = None
+        # Modules that were loaded as a script (``__main__``) and are
+        # re-executed from file under a substitute name: name -> path
+        self._script_modules: dict[str, Path] = {}
         self._target: Any = None
         self._state: dict | None = None
         self._watcher_id: int = id(self)  # Unique ID for SharedFileWatcher
@@ -252,8 +259,16 @@ class HotReloader:
         self._target = target
         self._state = state
 
-        # Collect all imported .cgx modules
-        self._collect_cgx_modules()
+        # Remember the root component's class name so the class can be
+        # looked up after reload of modules that don't set __component_class
+        # (plain Python modules with view components)
+        gui = self._gui_ref()
+        root_component = getattr(gui.fragment, "component", None) if gui else None
+        if root_component is not None:
+            self._root_class_name = type(root_component).__name__
+
+        # Collect all watched modules (.cgx files and view component modules)
+        self._collect_watched_modules()
 
         # Register with shared file watcher (unless disabled for testing)
         if self._watched_modules and self._use_watchdog:
@@ -314,9 +329,10 @@ class HotReloader:
         # Phase 1: Try to reimport modules (validate before unmounting)
         try:
             self._invalidate_modules()
-            module = importlib.import_module(self._root_module_name)
-            importlib.reload(module)
-            component_class = getattr(module, "__component_class")
+            module = self._reload_module(self._root_module_name)
+            # Script modules get reloaded under a substitute name
+            self._root_module_name = module.__name__
+            component_class = self._get_root_component_class(module)
         except Exception:
             logger.exception("Error during reload, keeping old UI")
             return False
@@ -344,7 +360,7 @@ class HotReloader:
             if element_state and new_root_element is not None:
                 gui.renderer.restore_element_state(new_root_element, element_state)
 
-            self._collect_cgx_modules()
+            self._collect_watched_modules()
 
             if self._use_watchdog:
                 SharedFileWatcher().update_paths(
@@ -361,17 +377,21 @@ class HotReloader:
         finally:
             gui._in_hot_reload = False
 
-    def _collect_cgx_modules(self) -> None:
-        """Collect CGX modules that are actually used in this Collagraph's tree.
+    def _collect_watched_modules(self) -> None:
+        """Collect the modules that are actually used in this Collagraph's tree.
 
         This includes:
         1. Modules whose components are currently rendered in the fragment tree
-        2. CGX modules imported by those modules (for dynamic :is="..." components)
+        2. Component modules imported by those modules (for dynamic :is="..."
+           components)
 
         The second case handles scenarios like:
         - parent.cgx imports child_a.cgx and child_b.cgx
         - parent.cgx uses :is="type_map(obj_type)" to dynamically select which to render
         - Even if child_a is not currently rendered, it should still be watched
+
+        Watched modules are .cgx files plus plain Python modules that define
+        view components (Component subclasses that override ``view``).
         """
         from collagraph.sfc.importer import get_loaded_cgx_modules
 
@@ -385,23 +405,28 @@ class HotReloader:
         # Find which modules are actually used in our fragment tree
         used_modules = self._collect_used_modules(gui.fragment)
 
-        # Expand to include CGX modules imported by used modules
+        # Expand to include component modules imported by used modules
         # This catches dynamically loaded components (via :is directive)
-        expanded_modules = self._expand_cgx_imports(used_modules, all_cgx)
+        expanded_modules = self._expand_component_imports(used_modules, all_cgx)
 
-        # Watch all expanded modules
-        self._watched_modules = {
-            path: name for name, path in all_cgx.items() if name in expanded_modules
-        }
+        # Watch all expanded modules that map to a file
+        watched: dict[Path, str] = {}
+        for name in expanded_modules:
+            if name in all_cgx:
+                watched[all_cgx[name]] = name
+            elif path := self._view_module_path(name):
+                watched[path] = name
+        self._watched_modules = watched
 
-    def _expand_cgx_imports(
+    def _expand_component_imports(
         self, used_modules: set[str], all_cgx: dict[str, Path]
     ) -> set[str]:
-        """Expand the set of used modules to include any CGX modules they import.
+        """Expand the set of used modules to include component modules they import.
 
-        This recursively finds all CGX modules that are imported (directly or
-        indirectly) by the currently used modules. This ensures that dynamically
-        loaded components (via :is directive) are also watched for hot reload.
+        This recursively finds all component modules (CGX files or view
+        component modules) that are imported (directly or indirectly) by the
+        currently used modules. This ensures that dynamically loaded components
+        (via :is directive) are also watched for hot reload.
 
         Args:
             used_modules: Module names currently used in the fragment tree
@@ -409,7 +434,7 @@ class HotReloader:
                 loaded CGX modules
 
         Returns:
-            Expanded set of module names including imported CGX dependencies
+            Expanded set of module names including imported component modules
         """
         from collagraph.component import Component
 
@@ -429,7 +454,7 @@ class HotReloader:
                 continue
 
             # Look through the module's namespace for Component subclasses
-            # that come from CGX modules
+            # that come from component modules
             for attr_name in dir(module):
                 try:
                     attr = getattr(module, attr_name)
@@ -442,13 +467,55 @@ class HotReloader:
                     and issubclass(attr, Component)
                     and attr is not Component
                 ):
-                    # Check if this component comes from a CGX module
+                    # Check if this component comes from a watchable module
                     component_module = attr.__module__
-                    if component_module in all_cgx and component_module not in expanded:
+                    if component_module in expanded:
+                        continue
+                    if (
+                        component_module in all_cgx
+                        or self._view_module_path(component_module) is not None
+                    ):
                         expanded.add(component_module)
                         to_check.append(component_module)
 
         return expanded
+
+    def _view_module_path(self, module_name: str) -> Path | None:
+        """Return the file path for a plain Python module with view components.
+
+        Returns None when the module is not backed by a .py file or does not
+        define any Component subclass that overrides ``view``.
+        """
+        from collagraph.component import Component
+
+        module = sys.modules.get(module_name)
+        if module is None:
+            return None
+        path = self._module_file(module)
+        if path is None:
+            return None
+
+        for attr in list(vars(module).values()):
+            if (
+                isinstance(attr, type)
+                and issubclass(attr, Component)
+                and attr is not Component
+                and attr.__module__ == module.__name__
+                and attr.view is not Component.view
+            ):
+                return path
+        return None
+
+    @staticmethod
+    def _module_file(module: ModuleType) -> Path | None:
+        """Return the resolved .py path backing a module, if any."""
+        file = getattr(module, "__file__", None)
+        if not file:
+            return None
+        path = Path(file)
+        if path.suffix != ".py" or not path.is_file():
+            return None
+        return path.resolve()
 
     def _on_file_changed(self, path: Path) -> None:
         """Handle a file change event (called from watchdog thread)."""
@@ -509,15 +576,111 @@ class HotReloader:
         self.reload()
 
     def _invalidate_modules(self) -> None:
-        """Remove tracked CGX modules from sys.modules."""
+        """Remove tracked modules from sys.modules."""
         from collagraph.sfc.importer import clear_cgx_module
 
         for module_name in list(self._watched_modules.values()):
+            # Script modules can't be reimported through the import machinery;
+            # they are re-executed from file by _reload_module instead
+            if module_name == "__main__" or module_name in self._script_modules:
+                continue
             # Remove from sys.modules to force reimport
             if module_name in sys.modules:
                 del sys.modules[module_name]
             # Clear from CGX loader registry
             clear_cgx_module(module_name)
+
+    def _reload_module(self, module_name: str) -> ModuleType:
+        """Reimport a single watched module and return the new module.
+
+        Modules that were loaded as a script (``__main__``) can't go through
+        the import machinery again: re-executing them under the ``__main__``
+        name would trigger their ``if __name__ == "__main__"`` block. Those
+        are re-executed from file under a substitute name instead.
+        """
+        from collagraph.sfc.importer import clear_cgx_module
+
+        if module_name == "__main__" or module_name in self._script_modules:
+            return self._reload_script_module(module_name)
+
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+        clear_cgx_module(module_name)
+        for path, name in self._watched_modules.items():
+            if name == module_name:
+                self._clear_bytecode_cache(path)
+                break
+        return importlib.import_module(module_name)
+
+    @staticmethod
+    def _clear_bytecode_cache(path: Path) -> None:
+        """Remove compiled bytecode for a source file before reimporting it.
+
+        A rewrite can leave the source with the same size and mtime (in
+        seconds), which makes the import machinery consider the cached .pyc
+        fresh and reimport stale code.
+        """
+        if path.suffix != ".py":
+            return
+        try:
+            cached = Path(importlib.util.cache_from_source(str(path)))
+            cached.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    def _reload_script_module(self, module_name: str) -> ModuleType:
+        """Re-execute a script module from file under a substitute name."""
+        if module_name in self._script_modules:
+            path = self._script_modules[module_name]
+        else:
+            path = Path(sys.modules[module_name].__file__).resolve()
+
+        self._clear_bytecode_cache(path)
+        new_name = self._script_module_name(path)
+        spec = importlib.util.spec_from_file_location(new_name, path)
+        module = importlib.util.module_from_spec(spec)
+        # Register before exec so imports within the module can resolve it
+        previous = sys.modules.get(new_name)
+        sys.modules[new_name] = module
+        try:
+            spec.loader.exec_module(module)
+        except Exception:
+            # Restore the previous (working) version of the module
+            if previous is not None:
+                sys.modules[new_name] = previous
+            else:
+                sys.modules.pop(new_name, None)
+            raise
+
+        self._script_modules[new_name] = path
+        # Point the watcher entry for this file at the substitute name so
+        # subsequent changes map to the module that is now in use
+        if path in self._watched_modules:
+            self._watched_modules[path] = new_name
+        return module
+
+    def _script_module_name(self, path: Path) -> str:
+        """Pick a stable, importable substitute name for a script module."""
+        name = path.stem
+        if not name.isidentifier():
+            name = "_cg_script"
+        existing = sys.modules.get(name)
+        if existing is not None and self._module_file(existing) != path:
+            name = f"_cg_main_{name}"
+        return name
+
+    def _get_root_component_class(self, module: ModuleType) -> type:
+        """Find the root component class in a freshly reloaded root module."""
+        # CGX modules mark their component class explicitly
+        component_class = getattr(module, "__component_class", None)
+        if component_class is None and self._root_class_name:
+            # Plain Python modules: look up the class by its original name
+            component_class = getattr(module, self._root_class_name, None)
+        if component_class is None:
+            raise RuntimeError(
+                f"Could not find root component class in module {module.__name__!r}"
+            )
+        return component_class
 
     def _reload_changed_files(
         self, changed_paths: set[Path], preserve_state: bool = True
@@ -527,8 +690,6 @@ class HotReloader:
 
         Returns True if fine-grained reload succeeded, False if full reload needed.
         """
-        from collagraph.sfc.importer import clear_cgx_module
-
         gui = self._gui_ref()
         if gui is None or gui.fragment is None:
             return False
@@ -561,15 +722,12 @@ class HotReloader:
         )
 
         # Phase 1: Try to reload the changed modules (validate before unmounting)
+        # Keep track of the new module per (old) module name, since script
+        # modules get reloaded under a substitute name
+        reloaded_modules: dict[str, ModuleType] = {}
         try:
             for module_name in changed_modules:
-                # Clear from sys.modules and CGX registry
-                if module_name in sys.modules:
-                    del sys.modules[module_name]
-                clear_cgx_module(module_name)
-
-                # Reimport to validate
-                importlib.import_module(module_name)
+                reloaded_modules[module_name] = self._reload_module(module_name)
         except Exception:
             logger.exception("Error reloading module, keeping old UI")
             return False
@@ -580,7 +738,7 @@ class HotReloader:
         # Phase 2: Remount affected fragments
         try:
             for fragment in affected:
-                self._remount_fragment(fragment, preserve_state)
+                self._remount_fragment(fragment, preserve_state, reloaded_modules)
 
             logger.info("Fine-grained reload complete")
             return True
@@ -627,7 +785,12 @@ class HotReloader:
 
         return False
 
-    def _remount_fragment(self, fragment: Fragment, preserve_state: bool) -> None:
+    def _remount_fragment(
+        self,
+        fragment: Fragment,
+        preserve_state: bool,
+        reloaded_modules: dict[str, ModuleType] | None = None,
+    ) -> None:
         """Remount a single ComponentFragment with updated component class.
 
         Handles fragments in various locations:
@@ -684,7 +847,9 @@ class HotReloader:
         fragment.unmount(destroy=True)
 
         # Get the new component class from the reloaded module
-        module = sys.modules.get(module_name)
+        module = (reloaded_modules or {}).get(module_name)
+        if module is None:
+            module = sys.modules.get(module_name)
         if module is None:
             module = importlib.import_module(module_name)
 

--- a/docs/examples/pyside-examples.md
+++ b/docs/examples/pyside-examples.md
@@ -117,6 +117,10 @@ The counter and todo examples are also available written with the pure-Python [v
 ```sh
 uv run python examples/pyside/counter_view.py
 uv run python examples/pyside/todo_view.py
+
+# or through the CLI (e.g. with hot reload):
+uv run collagraph -H examples/pyside/counter_view.py
+uv run collagraph -H examples/pyside/todo_view.py:TodoApp
 ```
 
 ## More Examples

--- a/docs/examples/pyside-examples.md
+++ b/docs/examples/pyside-examples.md
@@ -33,7 +33,7 @@ class Counter(cg.Component):
 Demonstrates list management, text input, events, and child components:
 
 ```html title="todo_example.cgx"
-<window title="My First TODO app">
+<window window_title="My First TODO app">
   <widget name="main-content">
     <label text="What do you want to do?" />
     <lineedit :text="text" @text_edited="handle_change" />

--- a/docs/examples/pyside-examples.md
+++ b/docs/examples/pyside-examples.md
@@ -110,6 +110,15 @@ Collagraph supports all standard Qt layouts:
 </window>
 ```
 
+## Python Views
+
+The counter and todo examples are also available written with the pure-Python [view API](../guide/python-views.md), without `.cgx` templates:
+
+```sh
+uv run python examples/pyside/counter_view.py
+uv run python examples/pyside/todo_view.py
+```
+
 ## More Examples
 
 See the [`examples/pyside/`](https://github.com/fork-tongue/collagraph/tree/master/examples/pyside) directory for:

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -5,14 +5,22 @@ Collagraph includes a CLI to run components directly without writing a Python en
 ## Usage
 
 ```sh
-collagraph [OPTIONS] <component.cgx>
+collagraph [OPTIONS] <component>
 ```
 
 Or with uv:
 
 ```sh
-uv run collagraph [OPTIONS] <component.cgx>
+uv run collagraph [OPTIONS] <component>
 ```
+
+The component can be a `.cgx` file or a `.py` module containing a [Python view](../guide/python-views.md) component. When a `.py` module defines multiple view components, select one by appending the class name:
+
+```sh
+uv run collagraph examples/pyside/todo_view.py:TodoApp
+```
+
+Alternatively, a module can mark its root component by assigning `__component_class = MyComponent` at module level.
 
 ## Options
 
@@ -21,13 +29,16 @@ uv run collagraph [OPTIONS] <component.cgx>
 | `--renderer {pyside,pygfx,dict}` | `pyside` | Renderer to use |
 | `--state <json>` | - | Initial state as JSON string or path to JSON file |
 | `--hot-reload`, `-H` | off | Enable hot reload (auto-update on file changes) |
-| `--show-code` | off | Pretty print the compiled Python code for the component and exit |
+| `--show-code` | off | Pretty print the compiled Python code for the component and exit (`.cgx` only) |
 
 ## Examples
 
 ```sh
 # Run a PySide component
 uv run collagraph examples/pyside/counter.cgx
+
+# Run a Python view component
+uv run collagraph examples/pyside/counter_view.py
 
 # Run a Pygfx component
 uv run collagraph --renderer pygfx examples/pygfx/pygfx-component.cgx

--- a/docs/guide/hot-reload.md
+++ b/docs/guide/hot-reload.md
@@ -1,6 +1,6 @@
 # Hot Reload
 
-Collagraph supports hot reload for development: edit a `.cgx` file and the running application updates without restarting.
+Collagraph supports hot reload for development: edit a `.cgx` file or a [Python view](python-views.md) component and the running application updates without restarting.
 
 ## Enabling Hot Reload
 
@@ -18,10 +18,24 @@ gui = cg.Collagraph(renderer=cg.PySideRenderer(), hot_reload=True)
 
 ## How It Works
 
-1. A file watcher (powered by [watchdog](https://github.com/gorakhargosh/watchdog)) monitors `.cgx` files
-2. When a file changes, its component is recompiled
-3. All instances of that component are re-rendered with their current state preserved
+1. A file watcher (powered by [watchdog](https://github.com/gorakhargosh/watchdog)) monitors the `.cgx` files and Python view component modules used in the component tree
+2. When a file changes, its module is recompiled/reimported
+3. All instances of its components are re-rendered with their current state preserved
 4. Renderer-specific state (e.g., window geometry) is saved and restored
+
+## Python View Components
+
+Hot reload also works for components that use the [view API](python-views.md) instead of a template. Any `.py` module that defines a view component used in the tree is watched. Since these run as regular Python scripts, enable hot reload programmatically:
+
+```python
+if __name__ == "__main__":
+    app = QtWidgets.QApplication()
+    gui = cg.Collagraph(renderer=cg.PySideRenderer(), hot_reload=True)
+    gui.render(Counter, app)
+    app.exec()
+```
+
+This works even when the component is defined in the script you run directly (the `__main__` module): on reload, the file is re-executed under a substitute module name, so the `if __name__ == "__main__":` block does **not** run again.
 
 ## State Preservation
 
@@ -35,4 +49,4 @@ During hot reload:
 
 - Changes to `init()` won't re-run (state is preserved, not re-initialized)
 - Structural changes to props may require a manual restart
-- Only works with `.cgx` files (not plain Python component definitions)
+- Plain Python modules are only watched when they define a view component (a `Component` subclass with a `view` method); other Python code, like utility modules, won't trigger a reload

--- a/docs/guide/python-views.md
+++ b/docs/guide/python-views.md
@@ -115,18 +115,18 @@ h.button("bump", on_clicked=self.bump)
 
 ## Conditional rendering
 
-`when`, `elif_` and `otherwise` are the equivalents of `v-if`, `v-else-if` and `v-else`. Content built inside the block is only rendered while the condition holds:
+`when`, `or_when` and `otherwise` are the equivalents of `v-if`, `v-else-if` and `v-else`. Content built inside the block is only rendered while the condition holds:
 
 ```python
 with cg.when(lambda: self.props["status"] == "loading"):
     h.label(text="Loading…")
-with cg.elif_(lambda: self.props["status"] == "error"):
+with cg.or_when(lambda: self.props["status"] == "error"):
     h.label(text="Error!")
 with cg.otherwise():
     h.label(text="Ready")
 ```
 
-Like `v-else-if`/`v-else` in templates, `elif_` and `otherwise` must directly follow the block they belong to. A branch may contain any number of elements.
+Like `v-else-if`/`v-else` in templates, `or_when` and `otherwise` must directly follow the block they belong to. A branch may contain any number of elements.
 
 !!! warning "Don't use a plain `if`"
     A regular Python `if` statement in `view` runs only once, when the view is built — the UI would never react to changes. Any condition that depends on state or props belongs in a `when`.
@@ -252,7 +252,7 @@ Then edit and save any module that defines a view component used in the tree —
 | `v-bind="attrs"` | `h.label(bind=lambda: attrs)` |
 | `@clicked="handler"` | `h.button(on_clicked=handler)` |
 | `<label>{{ expr }}</label>` | `h.label(lambda: expr)` |
-| `v-if` / `v-else-if` / `v-else` | `with cg.when(...)` / `cg.elif_(...)` / `cg.otherwise()` |
+| `v-if` / `v-else-if` / `v-else` | `with cg.when(...)` / `cg.or_when(...)` / `cg.otherwise()` |
 | `v-for="item in items"` + `:key` | `@cg.each(lambda: items, key=...)` |
 | `<MyComponent :prop="expr" />` | `h(MyComponent, prop=lambda: expr)` |
 | `<slot name="x">fallback</slot>` | `with cg.slot("x"): ...` |

--- a/docs/guide/python-views.md
+++ b/docs/guide/python-views.md
@@ -1,0 +1,254 @@
+# Python Views
+
+Besides `.cgx` templates, components can describe their UI in **plain Python**, using the element builder `h` in a `view` method:
+
+```python title="counter.py"
+import collagraph as cg
+from collagraph import h
+
+
+class Counter(cg.Component):
+    def init(self):
+        self.state["count"] = 0
+
+    def bump(self):
+        self.state["count"] += 1
+
+    def view(self):
+        with h.widget():
+            h.label(text=lambda: f"Count: {self.state['count']}")
+            h.button("bump", on_clicked=self.bump)
+```
+
+Both styles are fully supported and can be mixed freely in one application: a `.cgx` component can use a Python-view component as a child and vice versa. Python views are just regular Python, so type checkers, linters, formatters, debuggers and IDEs work out of the box — no plugins needed.
+
+## How it works
+
+The `view` method runs **once**, when the component is created — just like the render function that is compiled from a `.cgx` template. It builds a tree of elements; afterwards, fine-grained reactivity keeps the UI up to date without ever re-running `view`.
+
+That works through one rule:
+
+!!! tip "The one rule"
+    **A plain value is static, a zero-argument callable is live.**
+
+    ```python
+    h.label(text="never changes")                           # static
+    h.label(text=lambda: f"Count: {self.state['count']}")   # updates reactively
+    ```
+
+Everything dynamic — attribute values, text, conditions, list expressions — is passed as a callable (usually a `lambda`). Collagraph watches each callable and updates exactly the thing it is bound to when its value changes, comparable to how [Solid](https://www.solidjs.com) works in the JavaScript world.
+
+Unlike in templates, there is no name resolution magic: expressions are ordinary closures, so state is accessed as `self.state["count"]` (not `count`).
+
+## Elements
+
+`h` creates elements. Use attribute access for regular elements and pass component classes directly:
+
+```python
+h.label(text="plain element")     # equivalent to h("label", ...)
+h("flow-layout")                  # tags that aren't valid identifiers
+h(TodoList, items=lambda: ...)    # child component
+```
+
+Nest elements with `with`:
+
+```python
+def view(self):
+    with h.widget():
+        h.label(text="one")
+        with h.widget(layout={"type": "Box", "direction": "LeftToRight"}):
+            h.label(text="two")
+```
+
+Just like templates, a view can have multiple root elements.
+
+## Attributes
+
+Keyword arguments become attributes, following the one rule:
+
+```python
+h.button(
+    text="Add",                                # static (like text="Add")
+    enabled=lambda: len(self.state["items"]),  # bound (like :enabled="...")
+)
+```
+
+Attribute names with dashes are written with underscores (`maximum_size` instead of `maximum-size`); the PySide renderer treats them the same.
+
+To bind a whole dict of attributes at once (`v-bind="attrs"`), use the `bind` keyword:
+
+```python
+h.label(bind=lambda: self.props["attrs"])
+```
+
+To pass an actual function object as a static attribute value (which would otherwise be interpreted as a live binding), wrap it in `cg.static`:
+
+```python
+h.item(sort_function=cg.static(natural_sort))
+```
+
+## Events
+
+Keyword arguments starting with `on_` register event handlers (`@clicked` in templates):
+
+```python
+h.button(text="Add", on_clicked=self.handle_submit)
+h.lineedit(on_text_edited=self.handle_change)
+```
+
+Handlers are regular callables and receive whatever arguments the event emits.
+
+## Text content
+
+Positional arguments become text content — the equivalent of `{{ interpolation }}`:
+
+```python
+h.label("static text")
+h.label(lambda: f"Count: {self.state['count']}")
+h.button("bump", on_clicked=self.bump)
+```
+
+!!! note "Renderer support"
+    Like text in templates, this requires the renderer to support text elements. For other elements, set text through an attribute such as `text=`.
+
+## Conditional rendering
+
+`when`, `elif_` and `otherwise` are the equivalents of `v-if`, `v-else-if` and `v-else`. Content built inside the block is only rendered while the condition holds:
+
+```python
+with cg.when(lambda: self.props["status"] == "loading"):
+    h.label(text="Loading…")
+with cg.elif_(lambda: self.props["status"] == "error"):
+    h.label(text="Error!")
+with cg.otherwise():
+    h.label(text="Ready")
+```
+
+Like `v-else-if`/`v-else` in templates, `elif_` and `otherwise` must directly follow the block they belong to. A branch may contain any number of elements.
+
+!!! warning "Don't use a plain `if`"
+    A regular Python `if` statement in `view` runs only once, when the view is built — the UI would never react to changes. Any condition that depends on state or props belongs in a `when`.
+
+## List rendering
+
+`each` is the equivalent of `v-for`. It decorates a function that builds the content for a single item:
+
+```python
+with h.widget():
+
+    @cg.each(lambda: self.state["items"], key=lambda item: item["id"])
+    def _(item):
+        h.label(text=lambda: item()["text"])
+```
+
+The function receives the loop variable as a **getter**: a zero-argument callable returning the current value. Call it *inside* your lambdas (`item()`), so that the read happens whenever the binding updates — this is what allows collagraph to update items in place instead of rebuilding the list.
+
+Multiple loop variables work through the function signature, like tuple unpacking in a `for` statement:
+
+```python
+@cg.each(lambda: enumerate(self.state["items"]))
+def _(index, item):
+    h.label(text=lambda: f"{index()}: {item()}")
+```
+
+The `key` function is the equivalent of `:key`: it receives the item value and should return a unique, stable identifier. Providing it enables keyed reconciliation, so that reordering moves elements instead of recreating them.
+
+## Components
+
+Pass a component class to `h`, with props and event handlers as keyword arguments:
+
+```python
+h(
+    TodoList,
+    items=lambda: self.state["items"],   # bound prop (:items="items")
+    title="To do",                       # static prop
+    on_clicked=self.handle_complete,     # event handler (@clicked="...")
+)
+```
+
+The child component subscribes to `emit`-ed events through the `on_*` handlers, exactly like with templates.
+
+## Slots
+
+Declare a slot in a component's view with `cg.slot`; fallback content goes inside the block:
+
+```python
+class Card(cg.Component):
+    def view(self):
+        with h.widget():
+            with cg.slot("header"):
+                h.label(text="fallback header")
+            cg.slot()  # the "default" slot
+```
+
+Provide content from the parent with `cg.fill` (the equivalent of `<template v-slot:name>`). Content placed directly inside a component element goes to the default slot:
+
+```python
+with h(Card):
+    with cg.fill("header"):
+        h.label(text="header content")
+    h.label(text="this goes into the default slot")
+```
+
+## Template refs
+
+The `ref` attribute works the same as in templates:
+
+```python
+h.lineedit(ref="input")
+```
+
+After mounting, the element (or component instance) is available as `self.refs["input"]`.
+
+## Dynamic components
+
+`cg.dynamic` is the equivalent of `<component :is="...">`. The callable returns a component class (or tag string) and the element is swapped out reactively when the value changes:
+
+```python
+cg.dynamic(lambda: self.state["active_view"], items=lambda: self.state["items"])
+```
+
+## A common pitfall: eager reads
+
+Reading state or props *directly* in view code — instead of inside a lambda — bakes the value in statically:
+
+```python
+def view(self):
+    h.label(text=f"Count: {self.state['count']}")  # ⚠ never updates!
+```
+
+Collagraph detects this and emits a warning pointing out the fix:
+
+```
+UserWarning: Reactive value read during view build: ...
+Reads of state/props directly in view code are evaluated only once and
+will not update. Wrap the expression in a lambda to make it reactive.
+```
+
+The same applies inside `each` item functions: `h.label(text=item())` is an eager read, `h.label(text=lambda: item())` (or simply `h.label(text=item)`) is a live binding.
+
+## Template to Python cheat sheet
+
+| Template | Python view |
+|---|---|
+| `<label text="x" />` | `h.label(text="x")` |
+| `<label :text="expr" />` | `h.label(text=lambda: expr)` |
+| `v-bind="attrs"` | `h.label(bind=lambda: attrs)` |
+| `@clicked="handler"` | `h.button(on_clicked=handler)` |
+| `<label>{{ expr }}</label>` | `h.label(lambda: expr)` |
+| `v-if` / `v-else-if` / `v-else` | `with cg.when(...)` / `cg.elif_(...)` / `cg.otherwise()` |
+| `v-for="item in items"` + `:key` | `@cg.each(lambda: items, key=...)` |
+| `<MyComponent :prop="expr" />` | `h(MyComponent, prop=lambda: expr)` |
+| `<slot name="x">fallback</slot>` | `with cg.slot("x"): ...` |
+| `<template v-slot:x>` | `with cg.fill("x"): ...` |
+| `ref="name"` | `h.label(ref="name")` |
+| `<component :is="expr" />` | `cg.dynamic(lambda: expr)` |
+
+## Examples
+
+Runnable examples using Python views can be found in the repository:
+
+```sh
+uv run python examples/pyside/counter_view.py
+uv run python examples/pyside/todo_view.py
+```

--- a/docs/guide/python-views.md
+++ b/docs/guide/python-views.md
@@ -266,3 +266,10 @@ Runnable examples using Python views can be found in the repository:
 uv run python examples/pyside/counter_view.py
 uv run python examples/pyside/todo_view.py
 ```
+
+They can also be run through the [CLI](../getting-started/cli.md), just like `.cgx` files (append `:ClassName` when a module defines multiple view components):
+
+```sh
+uv run collagraph -H examples/pyside/counter_view.py
+uv run collagraph -H examples/pyside/todo_view.py:TodoApp
+```

--- a/docs/guide/python-views.md
+++ b/docs/guide/python-views.md
@@ -73,7 +73,9 @@ h.button(
 )
 ```
 
-Attribute names with dashes are written with underscores (`maximum_size` instead of `maximum-size`); the PySide renderer treats them the same.
+In templates an attribute name may be written with either dashes or underscores (`maximum-size` or `maximum_size`). In a Python view the name is a keyword argument, so it must be a valid identifier — always use underscores (`maximum_size`).
+
+Which attribute names are accepted, and how they map to the underlying object, is up to the renderer. See the attribute sections for the [PySide renderer](../renderers/pyside.md#attributes) and the [Pygfx renderer](../renderers/pygfx.md#attributes).
 
 To bind a whole dict of attributes at once (`v-bind="attrs"`), use the `bind` keyword:
 

--- a/docs/guide/python-views.md
+++ b/docs/guide/python-views.md
@@ -227,6 +227,20 @@ will not update. Wrap the expression in a lambda to make it reactive.
 
 The same applies inside `each` item functions: `h.label(text=item())` is an eager read, `h.label(text=lambda: item())` (or simply `h.label(text=item)`) is a live binding.
 
+## Hot reload
+
+[Hot reload](hot-reload.md) works for view components just like for `.cgx` files. Pass `hot_reload=True` when constructing the `Collagraph` instance:
+
+```python
+if __name__ == "__main__":
+    app = QtWidgets.QApplication()
+    gui = cg.Collagraph(renderer=cg.PySideRenderer(), hot_reload=True)
+    gui.render(Counter, app)
+    app.exec()
+```
+
+Then edit and save any module that defines a view component used in the tree — including the script you ran directly — and the running application updates in place, with component state preserved.
+
 ## Template to Python cheat sheet
 
 | Template | Python view |

--- a/docs/guide/template-syntax.md
+++ b/docs/guide/template-syntax.md
@@ -4,6 +4,9 @@ Collagraph uses a Vue-inspired template syntax. If you know Vue, you already kno
 
 For full Vue template syntax documentation, see: [Vue Template Syntax](https://vuejs.org/guide/essentials/template-syntax.html)
 
+!!! tip "Prefer plain Python?"
+    Everything on this page can also be expressed in pure Python, without a `.cgx` file. See [Python Views](python-views.md).
+
 ## File Format
 
 A `.cgx` file has a template section and a `<script>` section:

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ uv run collagraph counter.cgx
 
 - **Reactive state** -- powered by [observ](https://github.com/fork-tongue/observ), changes to state automatically update the UI
 - **Single-file components** -- Vue-like `.cgx` files with template + script
+- **Pure-Python views** -- prefer no templates? Describe the same UI in plain Python with the [view API](guide/python-views.md)
 - **Multiple renderers** -- PySide6 for desktop, Pygfx for 3D scenes
 - **Hot reload** -- edit components and see changes without restarting
 - **Familiar syntax** -- if you know Vue, you already know most of the template syntax

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -7,8 +7,8 @@
     If you just want to build UIs, the [Guide](../guide/components.md) has
     everything you need.
 
-Collagraph turns a declarative template into a live UI and keeps that UI in
-sync with your reactive state. Under the hood there are four cooperating
+Collagraph turns a declarative UI description into a live UI and keeps that UI
+in sync with your reactive state. Under the hood there are four cooperating
 pieces:
 
 - **The compiler** ([`collagraph.sfc`](https://github.com/fork-tongue/collagraph/tree/main/collagraph/sfc)) —
@@ -26,6 +26,16 @@ pieces:
   Every dynamic part of the template is wrapped in an observ `watch`/`computed`
   so that a change to state re-runs *only* the affected piece of the UI.
 
+The compiler is not the only way to build that Fragment tree. A component can
+also describe its UI in **plain Python** by implementing a `view` method
+instead of a `.cgx` template. The pure-Python
+[view API](../guide/python-views.md) (`h`, `when`, `each`, …) builds the *same*
+Fragment tree directly, with no compile step — so `.cgx` and `view`-based
+components can be mixed freely. Everything below the Fragment tree — the
+Fragments, renderers and observ — is shared by both front-ends. This page uses
+`.cgx` examples throughout, but every mechanism it describes applies unchanged
+to a `view`-based component.
+
 At a glance, the whole system looks like this:
 
 ```mermaid
@@ -33,9 +43,11 @@ flowchart TD
     subgraph authoring [Authoring time]
         CGX[".cgx single-file component"]
         Compiler["SFC compiler<br/>(collagraph/sfc)"]
+        View["view() method<br/>(pure-Python view API)"]
         Render["Component.render()<br/>builds a Fragment tree"]
         CGX -->|compiles to| Compiler
         Compiler -->|injects| Render
+        View -->|build_view() runs it| Render
     end
 
     subgraph runtime [Runtime]
@@ -253,6 +265,29 @@ flowchart TD
     B --> T1
 ```
 
+### The same tree from Python
+
+A `view` method reaches the very same Fragment tree without a compile step. The
+counter above, written with the [view API](../guide/python-views.md):
+
+```python title="counter.py"
+def view(self):
+    with h.widget():
+        h.label(lambda: f"Count: {self.state['count']}")
+        h.button("bump", on_clicked=self.bump)
+```
+
+`build_view()` — called by the default `Component.render` when a component
+defines `view` instead of a template — runs this method once while an element
+builder records each `h(...)` call as a `Fragment` and each keyword/positional
+argument as a `set_bind`, `set_event` or `set_attribute`. The result is exactly
+the `ComponentFragment` → `widget` → `label`/`button` tree shown above. Where
+the `.cgx` compiler *generates* that wiring as `render()` source, the view API
+*performs* the equivalent calls directly at runtime; the one rule "a plain value
+is static, a callable is live" is just the runtime counterpart of the compiler's
+`text="x"` vs `:text="expr"` distinction. From `mount()` onward the two are
+indistinguishable.
+
 Control flow gets its own fragment type. `v-for` compiles to a `ListFragment`
 plus a **factory function** that builds one subtree per item:
 
@@ -422,8 +457,9 @@ suite). See the [Renderers Overview](../renderers/overview.md) for details.
 
 ```mermaid
 flowchart TD
-    subgraph compile ["1. Compile"]
+    subgraph compile ["1. Build the tree"]
         CGX[".cgx"] --> RENDER["render() builds<br/>Fragment tree"]
+        VIEW["view()"] --> RENDER
     end
     subgraph mount ["2. Mount"]
         RENDER --> FT["Fragment tree"]
@@ -438,7 +474,8 @@ flowchart TD
     end
 ```
 
-- The **compiler** decides *what* fragments exist (static structure).
+- The **compiler** (or a hand-written `view` method) decides *what* fragments
+  exist (static structure).
 - **Fragments** decide *when* elements exist and *how* they update (reactive
   structure).
 - The **renderer** decides *how* elements are actually made and mutated
@@ -446,6 +483,7 @@ flowchart TD
 - **observ** decides *why* an update happens and *when* it runs (reactivity +
   scheduling).
 
-That separation is the whole architecture: a static description compiled once,
-a reactive layer that mounts and surgically updates it, and a pluggable renderer
-that makes it real on whatever toolkit you point it at.
+That separation is the whole architecture: a static description built once
+(compiled from a `.cgx` template or assembled by a `view` method), a reactive
+layer that mounts and surgically updates it, and a pluggable renderer that makes
+it real on whatever toolkit you point it at.

--- a/docs/renderers/pyside.md
+++ b/docs/renderers/pyside.md
@@ -77,6 +77,16 @@ Attributes map to setter methods on the Qt widget. The attribute name is convert
 <button enabled="false" />    <!-- calls setEnabled(False) -->
 ```
 
+Multi-word attribute names may be written with either dashes or underscores; both map to the same camel-cased setter:
+
+```html
+<widget maximum-size="(200, 100)" />   <!-- calls setMaximumSize((200, 100)) -->
+<widget maximum_size="(200, 100)" />   <!-- same setter -->
+<widget window_title="My App" />       <!-- calls setWindowTitle("My App") -->
+```
+
+In [Python views](../guide/python-views.md), attribute names are keyword arguments, so only the underscore form works (`maximum_size=(200, 100)`).
+
 Dynamic attributes use Python expressions:
 
 ```html

--- a/examples/pyside/counter_view.py
+++ b/examples/pyside/counter_view.py
@@ -1,0 +1,32 @@
+"""
+Counter example written with the pure-Python view API
+(the equivalent of counter.cgx, without a template).
+
+Run this example as follows:
+uv run python examples/pyside/counter_view.py
+"""
+
+from PySide6 import QtWidgets
+
+import collagraph as cg
+from collagraph import h
+
+
+class Counter(cg.Component):
+    def init(self):
+        self.state["count"] = 0
+
+    def bump(self):
+        self.state["count"] += 1
+
+    def view(self):
+        with h.widget():
+            h.label(lambda: f"Count: {self.state['count']}")
+            h.button("bump", on_clicked=self.bump)
+
+
+if __name__ == "__main__":
+    app = QtWidgets.QApplication()
+    gui = cg.Collagraph(renderer=cg.PySideRenderer())
+    gui.render(Counter, app)
+    app.exec()

--- a/examples/pyside/todo_example.cgx
+++ b/examples/pyside/todo_example.cgx
@@ -4,7 +4,7 @@ Example of how to render to PySide6 UI.
 Run this example as follows:
 uv run collagraph examples/pyside/todo_example.cgx
 -->
-<window title="My First TODO app">
+<window window_title="My First TODO app">
   <widget name="main-content">
     <label text="What do you want to do?" />
     <lineedit :text="text" @text_edited="handle_change" />

--- a/examples/pyside/todo_view.py
+++ b/examples/pyside/todo_view.py
@@ -1,0 +1,79 @@
+"""
+TODO app written with the pure-Python view API (the equivalent of
+todo_example.cgx and todo_list.cgx, without templates).
+
+Run this example as follows:
+uv run python examples/pyside/todo_view.py
+"""
+
+from PySide6 import QtWidgets
+
+import collagraph as cg
+from collagraph import h
+
+
+class TodoList(cg.Component):
+    def complete(self, item):
+        self.emit("clicked", item)
+
+    def view(self):
+        with h.widget():
+
+            @cg.each(lambda: self.props["items"], key=lambda item: item)
+            def _(item):
+                with h.widget(layout={"type": "Box", "direction": "LeftToRight"}):
+                    h.button(
+                        text="✔️",
+                        checked=False,
+                        maximum_size=(40, 40),
+                        on_clicked=lambda: self.complete(item()),
+                    )
+                    h.label(text=item)
+
+
+class TodoApp(cg.Component):
+    def init(self):
+        self.state["items"] = [
+            "Groceries",
+            "Laundry",
+        ]
+        self.state["text"] = ""
+
+    def handle_change(self, text):
+        self.state["text"] = text
+
+    def handle_submit(self):
+        if todo := self.state["text"]:
+            if todo in self.state["items"]:
+                return
+            self.state["items"].append(todo)
+            self.state["text"] = ""
+
+    def handle_complete(self, item):
+        self.state["items"].remove(item)
+
+    def view(self):
+        with h.window(window_title="My first TODO app"):
+            with h.widget(name="main-content"):
+                h.label(text="What do you want to do?")
+                h.lineedit(
+                    text=lambda: self.state["text"],
+                    on_text_edited=self.handle_change,
+                )
+                h.button(text="Add", on_clicked=self.handle_submit)
+                with cg.when(lambda: len(self.state["items"]) > 0):
+                    h.label(text="To do:")
+                    h(
+                        TodoList,
+                        items=lambda: self.state["items"],
+                        on_clicked=self.handle_complete,
+                    )
+                with cg.otherwise():
+                    h.label(text="All done! 🎉")
+
+
+if __name__ == "__main__":
+    app = QtWidgets.QApplication()
+    gui = cg.Collagraph(renderer=cg.PySideRenderer())
+    gui.render(TodoApp, app)
+    app.exec()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
   - Guide:
       - Components: guide/components.md
       - Template Syntax: guide/template-syntax.md
+      - Python Views: guide/python-views.md
       - Reactivity: guide/reactivity.md
       - Events: guide/events.md
       - Slots: guide/slots.md

--- a/tests/test_cli_view.py
+++ b/tests/test_cli_view.py
@@ -1,0 +1,139 @@
+"""Tests for running Python view components through the CLI."""
+
+import argparse
+import sys
+import tempfile
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from collagraph.__main__ import existing_component_file, load_component_class, run
+
+SINGLE_COMPONENT = """
+import collagraph as cg
+from collagraph import h
+
+
+class Single(cg.Component):
+    def view(self):
+        h.label(text="single")
+"""
+
+MULTIPLE_COMPONENTS = """
+import collagraph as cg
+from collagraph import h
+
+
+class Child(cg.Component):
+    def view(self):
+        h.label(text="child")
+
+
+class App(cg.Component):
+    def view(self):
+        with h.widget():
+            h(Child)
+"""
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        inserted = []
+        yield Path(tmpdir), inserted
+        # load_component_class inserts the module directory into sys.path
+        resolved = str(Path(tmpdir).resolve())
+        if resolved in sys.path:
+            sys.path.remove(resolved)
+        for name in inserted:
+            sys.modules.pop(name, None)
+
+
+def test_component_argument_parsing(tmp_path):
+    py_path = tmp_path / "some_component.py"
+    py_path.write_text("")
+
+    assert existing_component_file(str(py_path)) == (py_path, None)
+    assert existing_component_file(f"{py_path}:MyClass") == (py_path, "MyClass")
+
+    with pytest.raises(argparse.ArgumentTypeError, match="does not exist"):
+        existing_component_file(str(tmp_path / "missing.py"))
+
+    txt_path = tmp_path / "not_a_component.txt"
+    txt_path.write_text("")
+    with pytest.raises(argparse.ArgumentTypeError, match="not a collagraph component"):
+        existing_component_file(str(txt_path))
+
+    cgx_path = tmp_path / "some_component.cgx"
+    cgx_path.write_text("")
+    with pytest.raises(argparse.ArgumentTypeError, match=r"only supported for \.py"):
+        existing_component_file(f"{cgx_path}:MyClass")
+
+
+def test_load_single_view_component(temp_dir):
+    tmpdir, inserted = temp_dir
+    path = tmpdir / "cli_single_view.py"
+    path.write_text(dedent(SINGLE_COMPONENT).lstrip())
+    inserted.append("cli_single_view")
+
+    component_class = load_component_class(path)
+    assert component_class.__name__ == "Single"
+
+
+def test_load_selected_view_component(temp_dir):
+    tmpdir, inserted = temp_dir
+    path = tmpdir / "cli_multi_view.py"
+    path.write_text(dedent(MULTIPLE_COMPONENTS).lstrip())
+    inserted.append("cli_multi_view")
+
+    component_class = load_component_class(path, "App")
+    assert component_class.__name__ == "App"
+
+    with pytest.raises(SystemExit, match="is not a Component subclass"):
+        load_component_class(path, "Missing")
+
+
+def test_load_multiple_view_components_requires_selection(temp_dir):
+    tmpdir, inserted = temp_dir
+    path = tmpdir / "cli_ambiguous_view.py"
+    path.write_text(dedent(MULTIPLE_COMPONENTS).lstrip())
+    inserted.append("cli_ambiguous_view")
+
+    with pytest.raises(SystemExit, match=r"Multiple view components.*:App"):
+        load_component_class(path)
+
+
+def test_load_explicit_component_class(temp_dir):
+    """A module can mark its root component with __component_class."""
+    tmpdir, inserted = temp_dir
+    path = tmpdir / "cli_explicit_view.py"
+    path.write_text(
+        dedent(MULTIPLE_COMPONENTS).lstrip() + "\n__component_class = Child\n"
+    )
+    inserted.append("cli_explicit_view")
+
+    component_class = load_component_class(path)
+    assert component_class.__name__ == "Child"
+
+
+def test_load_no_view_component(temp_dir):
+    tmpdir, inserted = temp_dir
+    path = tmpdir / "cli_no_view.py"
+    path.write_text("x = 1\n")
+    inserted.append("cli_no_view")
+
+    with pytest.raises(SystemExit, match="No view component found"):
+        load_component_class(path)
+
+
+def test_show_code_rejects_py_files(monkeypatch, tmp_path, capsys):
+    path = tmp_path / "cli_show_code_view.py"
+    path.write_text(dedent(SINGLE_COMPONENT).lstrip())
+    monkeypatch.setattr(sys, "argv", ["collagraph", "--show-code", str(path)])
+
+    with pytest.raises(SystemExit):
+        run()
+
+    captured = capsys.readouterr()
+    assert "--show-code is only supported for .cgx files" in captured.err

--- a/tests/test_hot_reload_view.py
+++ b/tests/test_hot_reload_view.py
@@ -1,0 +1,374 @@
+"""Tests for hot reload of pure-Python view components."""
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+import collagraph as cg
+
+VIEW_COMPONENT_TEMPLATE = """
+import collagraph as cg
+from collagraph import h
+
+
+class TempViewComponent(cg.Component):
+    def init(self):
+        self.state["label_text"] = "{text}"
+
+    def view(self):
+        h.label(text=lambda: self.state["label_text"])
+"""
+
+
+@pytest.fixture
+def temp_view_module():
+    """Create a temporary .py view component module that can be modified."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        module_path = Path(tmpdir) / "temp_view_component.py"
+        module_path.write_text(
+            dedent(VIEW_COMPONENT_TEMPLATE.format(text="Initial")).lstrip()
+        )
+
+        sys.path.insert(0, tmpdir)
+
+        yield module_path
+
+        sys.path.remove(tmpdir)
+        for name in list(sys.modules.keys()):
+            if name.startswith("temp_view_component"):
+                del sys.modules[name]
+
+
+def make_gui():
+    return cg.Collagraph(
+        renderer=cg.DictRenderer(),
+        event_loop_type=cg.EventLoopType.SYNC,
+        hot_reload=True,
+        hot_reload_watchdog=False,
+    )
+
+
+def test_view_module_is_watched(temp_view_module):
+    """The .py file of a view component should end up in the watch list."""
+    import temp_view_component
+
+    gui = make_gui()
+    container = {"type": "root"}
+    gui.render(temp_view_component.TempViewComponent, container)
+
+    watched = gui._hot_reloader._watched_modules
+    assert watched.get(temp_view_module.resolve()) == "temp_view_component"
+
+
+def test_full_reload_updates_ui(temp_view_module):
+    """Full reload should pick up changes to a view component module."""
+    import temp_view_component
+
+    gui = make_gui()
+    container = {"type": "root"}
+    gui.render(temp_view_component.TempViewComponent, container)
+
+    label = container["children"][0]
+    assert label["type"] == "label"
+    assert label["attrs"]["text"] == "Initial"
+
+    temp_view_module.write_text(
+        dedent(VIEW_COMPONENT_TEMPLATE.format(text="Updated")).lstrip()
+    )
+
+    assert gui.reload(preserve_state=False) is True
+
+    label = container["children"][0]
+    assert label["attrs"]["text"] == "Updated"
+
+
+def test_full_reload_preserves_state(temp_view_module):
+    """Component state should survive a reload when preserve_state is set."""
+    import temp_view_component
+
+    gui = make_gui()
+    container = {"type": "root"}
+    gui.render(temp_view_component.TempViewComponent, container)
+
+    # Change state at runtime, as if the user interacted with the app
+    gui.fragment.component.state["label_text"] = "Runtime"
+    assert container["children"][0]["attrs"]["text"] == "Runtime"
+
+    temp_view_module.write_text(
+        dedent(VIEW_COMPONENT_TEMPLATE.format(text="Updated")).lstrip()
+    )
+
+    assert gui.reload(preserve_state=True) is True
+
+    # The runtime state wins over the new init value
+    assert container["children"][0]["attrs"]["text"] == "Runtime"
+
+
+def test_full_reload_handles_syntax_error(temp_view_module):
+    """A broken module should fail the reload and keep the old UI."""
+    import temp_view_component
+
+    gui = make_gui()
+    container = {"type": "root"}
+    gui.render(temp_view_component.TempViewComponent, container)
+
+    temp_view_module.write_text("def broken(:\n")
+
+    assert gui.reload() is False
+
+    label = container["children"][0]
+    assert label["attrs"]["text"] == "Initial"
+
+    # A subsequent fix should reload fine
+    temp_view_module.write_text(
+        dedent(VIEW_COMPONENT_TEMPLATE.format(text="Fixed")).lstrip()
+    )
+    assert gui.reload(preserve_state=False) is True
+    assert container["children"][0]["attrs"]["text"] == "Fixed"
+
+
+def test_fine_grained_reload_of_view_child():
+    """Changing a child view module should remount only that component."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+
+        child_path = tmpdir_path / "view_child.py"
+        child_path.write_text(
+            dedent(
+                """
+                import collagraph as cg
+                from collagraph import h
+
+
+                class ViewChild(cg.Component):
+                    def view(self):
+                        h.label(text="child v1")
+                """
+            ).lstrip()
+        )
+
+        parent_path = tmpdir_path / "view_parent.py"
+        parent_path.write_text(
+            dedent(
+                """
+                import collagraph as cg
+                from collagraph import h
+
+                from view_child import ViewChild
+
+
+                class ViewParent(cg.Component):
+                    def view(self):
+                        with h.widget():
+                            h.label(text="parent")
+                            h(ViewChild)
+                """
+            ).lstrip()
+        )
+
+        sys.path.insert(0, str(tmpdir_path))
+        try:
+            import view_parent
+
+            gui = make_gui()
+            container = {"type": "root"}
+            gui.render(view_parent.ViewParent, container)
+
+            widget = container["children"][0]
+            assert widget["children"][0]["attrs"]["text"] == "parent"
+            assert widget["children"][1]["attrs"]["text"] == "child v1"
+
+            # Both modules should be watched
+            watched = set(gui._hot_reloader._watched_modules.values())
+            assert watched == {"view_parent", "view_child"}
+
+            child_path.write_text(
+                dedent(
+                    """
+                    import collagraph as cg
+                    from collagraph import h
+
+
+                    class ViewChild(cg.Component):
+                        def view(self):
+                            h.label(text="child v2")
+                    """
+                ).lstrip()
+            )
+
+            result = gui._hot_reloader._reload_changed_files(
+                {child_path.resolve()}, preserve_state=False
+            )
+            assert result is True
+
+            widget = container["children"][0]
+            assert widget["children"][0]["attrs"]["text"] == "parent"
+            assert widget["children"][1]["attrs"]["text"] == "child v2"
+
+        finally:
+            sys.path.remove(str(tmpdir_path))
+            for name in ("view_parent", "view_child"):
+                sys.modules.pop(name, None)
+
+
+def test_cgx_root_with_view_child():
+    """A .cgx root importing a Python view component should watch both files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+
+        child_path = tmpdir_path / "mixed_view_child.py"
+        child_path.write_text(
+            dedent(
+                """
+                import collagraph as cg
+                from collagraph import h
+
+
+                class MixedViewChild(cg.Component):
+                    def view(self):
+                        h.label(text="child v1")
+                """
+            ).lstrip()
+        )
+
+        parent_path = tmpdir_path / "mixed_cgx_parent.cgx"
+        parent_path.write_text(
+            dedent(
+                """
+                <widget>
+                  <MixedViewChild />
+                </widget>
+
+                <script>
+                import collagraph as cg
+
+                from mixed_view_child import MixedViewChild
+
+
+                class MixedCgxParent(cg.Component):
+                    pass
+                </script>
+                """
+            ).lstrip()
+        )
+
+        sys.path.insert(0, str(tmpdir_path))
+        try:
+            import mixed_cgx_parent
+
+            gui = make_gui()
+            container = {"type": "root"}
+            gui.render(mixed_cgx_parent.MixedCgxParent, container)
+
+            widget = container["children"][0]
+            assert widget["children"][0]["attrs"]["text"] == "child v1"
+
+            watched = set(gui._hot_reloader._watched_modules.values())
+            assert watched == {"mixed_cgx_parent", "mixed_view_child"}
+
+            child_path.write_text(
+                dedent(
+                    """
+                    import collagraph as cg
+                    from collagraph import h
+
+
+                    class MixedViewChild(cg.Component):
+                        def view(self):
+                            h.label(text="child v2")
+                    """
+                ).lstrip()
+            )
+
+            result = gui._hot_reloader._reload_changed_files(
+                {child_path.resolve()}, preserve_state=False
+            )
+            assert result is True
+
+            widget = container["children"][0]
+            assert widget["children"][0]["attrs"]["text"] == "child v2"
+
+        finally:
+            sys.path.remove(str(tmpdir_path))
+            for name in ("mixed_cgx_parent", "mixed_view_child"):
+                sys.modules.pop(name, None)
+
+
+MAIN_SCRIPT_TEMPLATE = """
+import collagraph as cg
+from collagraph import h
+
+GUARD_RAN = False
+
+
+class MainViewApp(cg.Component):
+    def init(self):
+        self.state["label_text"] = "{text}"
+
+    def view(self):
+        h.label(text=lambda: self.state["label_text"])
+
+
+if __name__ == "__main__":
+    GUARD_RAN = True
+"""
+
+
+def test_reload_of_main_script_module(monkeypatch):
+    """Components defined in a script run as __main__ should hot reload.
+
+    On reload, the script is re-executed under a substitute module name so
+    that its ``if __name__ == "__main__"`` block does not run again.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        script_path = Path(tmpdir) / "main_view_script.py"
+        script_path.write_text(
+            dedent(MAIN_SCRIPT_TEMPLATE.format(text="Initial")).lstrip()
+        )
+
+        # Load the script the way `python main_view_script.py` would:
+        # as the __main__ module
+        spec = importlib.util.spec_from_file_location("__main__", script_path)
+        module = importlib.util.module_from_spec(spec)
+        monkeypatch.setitem(sys.modules, "__main__", module)
+        spec.loader.exec_module(module)
+        assert module.GUARD_RAN is True
+        assert module.MainViewApp.__module__ == "__main__"
+
+        try:
+            gui = make_gui()
+            container = {"type": "root"}
+            gui.render(module.MainViewApp, container)
+
+            assert gui._hot_reloader._root_module_name == "__main__"
+            label = container["children"][0]
+            assert label["attrs"]["text"] == "Initial"
+
+            script_path.write_text(
+                dedent(MAIN_SCRIPT_TEMPLATE.format(text="Updated")).lstrip()
+            )
+
+            assert gui.reload(preserve_state=False) is True
+
+            label = container["children"][0]
+            assert label["attrs"]["text"] == "Updated"
+
+            # The module was re-executed under a substitute name and its
+            # __main__ guard did not run
+            reloaded = sys.modules["main_view_script"]
+            assert reloaded.GUARD_RAN is False
+            assert gui._hot_reloader._root_module_name == "main_view_script"
+
+            # A second reload should go through the substitute module
+            script_path.write_text(
+                dedent(MAIN_SCRIPT_TEMPLATE.format(text="Again")).lstrip()
+            )
+            assert gui.reload(preserve_state=False) is True
+            assert container["children"][0]["attrs"]["text"] == "Again"
+
+        finally:
+            sys.modules.pop("main_view_script", None)

--- a/tests/test_view_dsl.py
+++ b/tests/test_view_dsl.py
@@ -97,7 +97,7 @@ def test_conditional_chain():
                 h.label(text="before")
                 with cg.when(lambda: self.props["status"] == "loading"):
                     h.label(text="Loading…")
-                with cg.elif_(lambda: self.props["status"] == "error"):
+                with cg.or_when(lambda: self.props["status"] == "error"):
                     h.label(text="Error!")
                     h.label(text="Please retry")
                 with cg.otherwise():
@@ -143,7 +143,7 @@ def test_two_independent_conditions():
     widget = container["children"][0]
     assert [child["attrs"]["text"] for child in widget["children"]] == ["a", "b"]
 
-    # Both conditions operate independently (no when/elif_ chain)
+    # Both conditions operate independently (no when/or_when chain)
     state["a"] = False
 
     assert [child["attrs"]["text"] for child in widget["children"]] == ["b"]
@@ -442,10 +442,10 @@ def test_eager_read_warning_in_each():
         render(App, state=state)
 
 
-def test_elif_without_when_raises():
+def test_or_when_without_when_raises():
     class App(cg.Component):
         def view(self):
-            with cg.elif_(lambda: True):
+            with cg.or_when(lambda: True):
                 h.label(text="nope")
 
     with pytest.raises(RuntimeError, match="must directly follow"):

--- a/tests/test_view_dsl.py
+++ b/tests/test_view_dsl.py
@@ -1,0 +1,465 @@
+"""Tests for the pure-Python view API (collagraph.dsl)."""
+
+import pytest
+from observ import reactive
+
+import collagraph as cg
+from collagraph import Collagraph, EventLoopType, h
+from collagraph.renderers import DictRenderer
+
+
+def render(component_class, state=None):
+    """Render the given component class into a fresh container."""
+    gui = Collagraph(
+        renderer=DictRenderer(),
+        event_loop_type=EventLoopType.SYNC,
+    )
+    container = {"type": "root"}
+    gui.render(component_class, container, state=state)
+    return gui, container
+
+
+def test_counter():
+    class Counter(cg.Component):
+        def init(self):
+            self.state["count"] = 0
+
+        def bump(self):
+            self.state["count"] += 1
+
+        def view(self):
+            with h.widget():
+                h.label(text=lambda: f"Count: {self.state['count']}")
+                h.button("bump", on_clicked=self.bump)
+
+    _, container = render(Counter)
+
+    widget = container["children"][0]
+    label, button = widget["children"]
+    assert label["attrs"]["text"] == "Count: 0"
+    assert button["children"][0]["text"] == "bump"
+
+    # Trigger the clicked event handler like a real button would
+    for handler in button["handlers"]["clicked"]:
+        handler()
+
+    assert label["attrs"]["text"] == "Count: 1"
+
+
+def test_static_and_bound_attributes():
+    class App(cg.Component):
+        def view(self):
+            h.label(
+                text="static",
+                maximum_size=(40, 40),
+                other=lambda: self.props["value"] * 2,
+            )
+
+    state = reactive({"value": 3})
+    _, container = render(App, state=state)
+
+    label = container["children"][0]
+    assert label["attrs"]["text"] == "static"
+    assert label["attrs"]["maximum_size"] == (40, 40)
+    assert label["attrs"]["other"] == 6
+
+    state["value"] = 5
+
+    assert label["attrs"]["other"] == 10
+
+
+def test_bind_dict():
+    class App(cg.Component):
+        def view(self):
+            h.label(bind=lambda: self.props["attrs"])
+
+    state = reactive({"attrs": {"text": "foo", "height": 100}})
+    _, container = render(App, state=state)
+
+    label = container["children"][0]
+    assert label["attrs"]["text"] == "foo"
+    assert label["attrs"]["height"] == 100
+
+    state["attrs"]["text"] = "bar"
+
+    assert label["attrs"]["text"] == "bar"
+
+    # Removing a key removes the attribute
+    del state["attrs"]["height"]
+
+    assert "height" not in label["attrs"]
+
+
+def test_conditional_chain():
+    class App(cg.Component):
+        def view(self):
+            with h.widget():
+                h.label(text="before")
+                with cg.when(lambda: self.props["status"] == "loading"):
+                    h.label(text="Loading…")
+                with cg.elif_(lambda: self.props["status"] == "error"):
+                    h.label(text="Error!")
+                    h.label(text="Please retry")
+                with cg.otherwise():
+                    h.label(text="Ready")
+                h.label(text="after")
+
+    state = reactive({"status": "loading"})
+    _, container = render(App, state=state)
+
+    widget = container["children"][0]
+
+    def texts():
+        return [child["attrs"]["text"] for child in widget["children"]]
+
+    assert texts() == ["before", "Loading…", "after"]
+
+    state["status"] = "error"
+
+    # A branch can render multiple children
+    assert texts() == ["before", "Error!", "Please retry", "after"]
+
+    state["status"] = "done"
+
+    assert texts() == ["before", "Ready", "after"]
+
+    state["status"] = "loading"
+
+    assert texts() == ["before", "Loading…", "after"]
+
+
+def test_two_independent_conditions():
+    class App(cg.Component):
+        def view(self):
+            with h.widget():
+                with cg.when(lambda: self.props["a"]):
+                    h.label(text="a")
+                with cg.when(lambda: self.props["b"]):
+                    h.label(text="b")
+
+    state = reactive({"a": True, "b": True})
+    _, container = render(App, state=state)
+
+    widget = container["children"][0]
+    assert [child["attrs"]["text"] for child in widget["children"]] == ["a", "b"]
+
+    # Both conditions operate independently (no when/elif_ chain)
+    state["a"] = False
+
+    assert [child["attrs"]["text"] for child in widget["children"]] == ["b"]
+
+
+def test_each_unkeyed():
+    class App(cg.Component):
+        def view(self):
+            with h.widget():
+
+                @cg.each(lambda: self.props["items"])
+                def _(item):
+                    h.label(text=lambda: item())
+
+    state = reactive({"items": ["a", "b"]})
+    _, container = render(App, state=state)
+
+    widget = container["children"][0]
+
+    def texts():
+        return [child["attrs"]["text"] for child in widget["children"]]
+
+    assert texts() == ["a", "b"]
+
+    state["items"].append("c")
+
+    assert texts() == ["a", "b", "c"]
+
+    state["items"].pop(0)
+
+    assert texts() == ["b", "c"]
+
+
+def test_each_multiple_loop_variables():
+    class App(cg.Component):
+        def view(self):
+            with h.widget():
+
+                @cg.each(lambda: enumerate(self.props["items"]))
+                def _(index, item):
+                    h.label(text=lambda: f"{index()}: {item()}")
+
+    state = reactive({"items": ["a", "b"]})
+    _, container = render(App, state=state)
+
+    widget = container["children"][0]
+    texts = [child["attrs"]["text"] for child in widget["children"]]
+    assert texts == ["0: a", "1: b"]
+
+
+def test_each_keyed_reuses_elements():
+    class App(cg.Component):
+        def view(self):
+            with h.widget():
+
+                @cg.each(
+                    lambda: self.props["items"],
+                    key=lambda item: item["id"],
+                )
+                def _(item):
+                    h.label(text=lambda: item()["text"])
+
+    state = reactive(
+        {
+            "items": [
+                {"id": 1, "text": "one"},
+                {"id": 2, "text": "two"},
+                {"id": 3, "text": "three"},
+            ]
+        }
+    )
+    _, container = render(App, state=state)
+
+    widget = container["children"][0]
+
+    def texts():
+        return [child["attrs"]["text"] for child in widget["children"]]
+
+    assert texts() == ["one", "two", "three"]
+    elements_by_text = {
+        child["attrs"]["text"]: id(child) for child in widget["children"]
+    }
+
+    # Reverse the list: elements should be moved, not recreated
+    state["items"].reverse()
+
+    assert texts() == ["three", "two", "one"]
+    for child in widget["children"]:
+        assert id(child) == elements_by_text[child["attrs"]["text"]]
+
+
+def test_each_with_events():
+    """Port of the todo_list.cgx example."""
+    clicked = []
+
+    class TodoList(cg.Component):
+        def clicked(self, item):
+            self.emit("clicked", item)
+
+        def view(self):
+            with h.widget():
+
+                @cg.each(lambda: self.props["items"])
+                def _(item):
+                    with h.widget():
+                        h.button(
+                            text="✔️",
+                            on_clicked=lambda: self.clicked(item()),
+                        )
+                        h.label(text=item)
+
+    class App(cg.Component):
+        def view(self):
+            h(TodoList, items=lambda: self.props["items"], on_clicked=clicked.append)
+
+    state = reactive({"items": ["groceries", "dishes"]})
+    _, container = render(App, state=state)
+
+    rows = container["children"][0]["children"]
+    assert [row["children"][1]["attrs"]["text"] for row in rows] == [
+        "groceries",
+        "dishes",
+    ]
+
+    button = rows[1]["children"][0]
+    for handler in button["handlers"]["clicked"]:
+        handler()
+
+    assert clicked == ["dishes"]
+
+
+def test_component_props_and_events():
+    class Child(cg.Component):
+        def view(self):
+            h.button(
+                text=lambda: self.props["label"],
+                on_clicked=lambda: self.emit("pressed", self.props["label"]),
+            )
+
+    pressed = []
+
+    class App(cg.Component):
+        def view(self):
+            h(Child, label=lambda: self.props["name"], on_pressed=pressed.append)
+
+    state = reactive({"name": "foo"})
+    _, container = render(App, state=state)
+
+    button = container["children"][0]
+    assert button["attrs"]["text"] == "foo"
+
+    state["name"] = "bar"
+
+    assert button["attrs"]["text"] == "bar"
+
+    for handler in button["handlers"]["clicked"]:
+        handler()
+
+    assert pressed == ["bar"]
+
+
+def test_slots():
+    """Port of the slots template example."""
+
+    class Layout(cg.Component):
+        def view(self):
+            with h.widget():
+                with h.widget(name="header"):
+                    with cg.slot("header"):
+                        h.label(text="fallback header")
+                with h.widget(name="content"):
+                    cg.slot()
+                with h.widget(name="footer"):
+                    with cg.slot("footer"):
+                        h.label(text="fallback footer")
+
+    class App(cg.Component):
+        def view(self):
+            with h(Layout):
+                with cg.fill("header"):
+                    h.label(text="header content")
+                h.label(text="content")
+                h.label(text="even more content")
+
+    _, container = render(App)
+
+    layout = container["children"][0]
+    header, content, footer = layout["children"]
+
+    assert [child["attrs"]["text"] for child in header["children"]] == [
+        "header content"
+    ]
+    # Content without an explicit fill() ends up in the default slot
+    assert [child["attrs"]["text"] for child in content["children"]] == [
+        "content",
+        "even more content",
+    ]
+    # No content provided for the footer slot: fallback is rendered
+    assert [child["attrs"]["text"] for child in footer["children"]] == [
+        "fallback footer"
+    ]
+
+
+def test_refs():
+    class App(cg.Component):
+        def view(self):
+            h.label(ref="label", text="referenced")
+
+    gui, container = render(App)
+
+    component = gui.fragment.component
+    # == instead of `is`: refs is a reactive dict, reads return a proxy
+    assert component.refs["label"] == container["children"][0]
+
+
+def test_dynamic_component():
+    class Foo(cg.Component):
+        def view(self):
+            h.label(text="foo")
+
+    class Bar(cg.Component):
+        def view(self):
+            h.label(text="bar")
+
+    class App(cg.Component):
+        def view(self):
+            cg.dynamic(lambda: Foo if self.props["foo"] else Bar)
+
+    state = reactive({"foo": True})
+    _, container = render(App, state=state)
+
+    assert container["children"][0]["attrs"]["text"] == "foo"
+
+    state["foo"] = False
+
+    assert container["children"][0]["attrs"]["text"] == "bar"
+
+
+def test_when_inside_each():
+    class App(cg.Component):
+        def view(self):
+            with h.widget():
+
+                @cg.each(lambda: self.props["items"])
+                def _(item):
+                    with cg.when(lambda: item()["done"]):
+                        h.label(text=lambda: f"{item()['text']} ✔")
+                    with cg.otherwise():
+                        h.label(text=lambda: item()["text"])
+
+    state = reactive(
+        {
+            "items": [
+                {"text": "groceries", "done": False},
+                {"text": "dishes", "done": True},
+            ]
+        }
+    )
+    _, container = render(App, state=state)
+
+    widget = container["children"][0]
+
+    def texts():
+        return [child["attrs"]["text"] for child in widget["children"]]
+
+    assert texts() == ["groceries", "dishes ✔"]
+
+    state["items"][0]["done"] = True
+
+    assert texts() == ["groceries ✔", "dishes ✔"]
+
+
+def test_eager_read_warning():
+    class App(cg.Component):
+        def init(self):
+            self.state["count"] = 0
+
+        def view(self):
+            # Bug: reads state during view build, bakes in the value
+            h.label(text=f"Count: {self.state['count']}")
+
+    with pytest.warns(UserWarning, match="Reactive value read during view build"):
+        render(App)
+
+
+def test_eager_read_warning_in_each():
+    class App(cg.Component):
+        def view(self):
+            @cg.each(lambda: self.props["items"])
+            def _(item):
+                # Bug: reads the item getter during build
+                h.label(text=item())
+
+    state = reactive({"items": ["a"]})
+    with pytest.warns(UserWarning, match="Reactive value read during view build"):
+        render(App, state=state)
+
+
+def test_elif_without_when_raises():
+    class App(cg.Component):
+        def view(self):
+            with cg.elif_(lambda: True):
+                h.label(text="nope")
+
+    with pytest.raises(RuntimeError, match="must directly follow"):
+        render(App)
+
+
+def test_h_outside_view_raises():
+    with pytest.raises(RuntimeError, match="No view is being built"):
+        h.label(text="nope")
+
+
+def test_no_view_and_no_template_raises():
+    class App(cg.Component):
+        pass
+
+    with pytest.raises(NotImplementedError, match="neither a template"):
+        render(App)


### PR DESCRIPTION
## What

Adds a pure-Python way to describe component UIs — the `view()` method — as a fully supported alternative to `.cgx` templates, for users who prefer to stay in plain Python (better tooling, type checkers, no separate file format):

```python
import collagraph as cg
from collagraph import h


class Counter(cg.Component):
    def init(self):
        self.state["count"] = 0

    def bump(self):
        self.state["count"] += 1

    def view(self):
        with h.widget():
            h.label(lambda: f"Count: {self.state['count']}")
            h.button("bump", on_clicked=self.bump)
```

Templates remain fully supported; the two coexist (a component defines either a template or a `view` method).

## How it works

Like compiled cgx render functions, `view()` runs **once** per component instance: it's a setup function that builds the same `Fragment` tree the compiler produces, so all fine-grained reactivity lives in the existing Fragment layer — no new reactivity machinery. The one rule: a plain value is a static attribute, a zero-arg callable is a reactive bind.

The full template feature set is covered: static/bound attributes and `bind=` dicts, events (`on_*`), text content, `when`/`elif_`/`otherwise`, keyed and unkeyed `each` loops (loop variables as Solid-style getters), component usage with props/events, slots and `fill`, refs, and `dynamic` (`:is`) components. View build code additionally runs inside a temporary watcher that detects the eager-read footgun (reading reactive state without wrapping it in a lambda) and warns with a pointer to the fix.

## Also in this PR

- **Hot reload for view components**: plain `.py` modules defining view components are watched and reloaded, including scripts run directly (`python my_app.py` — the file is re-executed under a substitute module name so the `__main__` guard doesn't re-fire). Also fixes a stale-bytecode edge where a same-size rewrite within the same mtime second would reload old code.
- **CLI support**: `collagraph -H examples/pyside/counter_view.py` works, with `file.py:ClassName` to select a class when a module defines several.
- **Examples** (`counter_view.py`, `todo_view.py`), a **docs guide** (Python Views, with a template→Python cheat sheet), and cross-links from the existing docs.
- Drive-by fix: `<window title=...>` in the todo example was a silent no-op (the Qt property is `windowTitle`); now uses `window_title`.

## Testing

- 33 new tests (view DSL, hot reload of view modules, CLI resolution); full suite passes.
- Examples verified end-to-end against an offscreen `QApplication`, including keyed list reconciliation and conditional switching.
- Hot reload verified end-to-end offscreen with the watchdog enabled: edit on disk → reload → state preserved → UI still interactive, both programmatically and through `collagraph -H`.
- `mkdocs build --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)