### PR TITLE
Migrate from pre-commit to prek

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ uv run python examples/pyside/layout-example.py
 # Run test suite:
 uv run pytest
 # Install git pre-commit hooks to make sure tests/linting passes before committing
-uv run pre-commit install
+uv run prek install
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ pyside = ["PySide6>=6.6.2,!=6.8.3,!=6.9.0 ; python_version < '3.15'"]
 [dependency-groups]
 dev = [
     "colorlog",
-    "pre-commit",
+    "prek",
     "pytest",
     "pytest-benchmark",
     "pytest-cov",


### PR DESCRIPTION
## What

Migrate the pre-commit tooling from [pre-commit](https://pre-commit.com) to [prek](https://github.com/j178/prek).

- Swap the `pre-commit` dev dependency for `prek` in `pyproject.toml`
- Update the install command in the README to `uv run prek install`

## Why

prek is a faster, dependency-light Rust reimplementation of pre-commit. It's a drop-in replacement that reads the existing `.pre-commit-config.yaml` unchanged, so no hook configuration changes are needed.

## Notes for reviewers

- `.pre-commit-config.yaml` is intentionally untouched — prek consumes it as-is.
- After pulling, run `uv sync --all-groups` and `uv run prek install --overwrite` to swap the local git hook from pre-commit to prek.
- Verified `uv run prek run --all-files` passes all three hooks (lint, format, pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)